### PR TITLE
docs(analyzers): detail rules and usage examples

### DIFF
--- a/docs/analyzers.rst
+++ b/docs/analyzers.rst
@@ -8,20 +8,159 @@ Enable optional analyzers in ``bumpwright.toml``:
    [analyzers]
    cli = true
    web_routes = true
-
-CLI Analyzer
-------------
-Tracks ``argparse`` or ``click`` command-line interfaces.
-
-Web Route Analyzer
-------------------
-Detects HTTP route changes in Flask or FastAPI apps.
-
-Migrations Analyzer
--------------------
-Scans Alembic migrations for schema impacts. Configure paths:
-
-.. code-block:: toml
+   migrations = true
 
    [migrations]
    paths = ["migrations"]
+
+CLI Analyzer
+------------
+
+Tracks ``argparse`` or ``click`` command-line interfaces.
+
+Dependencies
+~~~~~~~~~~~~
+
+* ``click`` (optional for click-based CLIs)
+
+Enable or disable
+~~~~~~~~~~~~~~~~~
+
+Set ``cli`` under ``[analyzers]`` to ``true`` or ``false``.
+
+.. code-block:: toml
+
+   [analyzers]
+   cli = true  # set to false to disable
+
+Severity rules
+~~~~~~~~~~~~~~
+
+* Added command → minor
+* Removed command → major
+* Added optional option → minor
+* Added required option → major
+* Removed optional option → minor
+* Removed required option → major
+* Option became optional → minor
+* Option became required → major
+
+Detectable change
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: diff
+
+   @@
+   @click.command()
+   def greet(name):
+       ...
+
+   +@click.option("--force", required=True)
+   +def greet(name, force):
+   +    ...
+
+Example output
+~~~~~~~~~~~~~~
+
+::
+
+   - [MAJOR] greet: Added required option '--force'
+
+Web Route Analyzer
+------------------
+
+Detects HTTP route changes in Flask or FastAPI apps.
+
+Dependencies
+~~~~~~~~~~~~
+
+* ``Flask`` or ``FastAPI``
+
+Enable or disable
+~~~~~~~~~~~~~~~~~
+
+Set ``web_routes`` under ``[analyzers]``.
+
+.. code-block:: toml
+
+   [analyzers]
+   web_routes = true  # set to false to disable
+
+Severity rules
+~~~~~~~~~~~~~~
+
+* Added route → minor
+* Removed route → major
+* Added optional param → minor
+* Added required param → major
+* Removed optional param → minor
+* Removed required param → major
+* Param became optional → minor
+* Param became required → major
+
+Detectable change
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: diff
+
+   @@
+   @app.get("/users/{user_id}")
+   -def get_user(user_id: int):
+   -    ...
+   +def get_user(user_id: int, verbose: bool = False):
+   +    ...
+
+Example output
+~~~~~~~~~~~~~~
+
+::
+
+   - [MINOR] GET /users/{user_id}: Added optional param 'verbose'
+
+Migrations Analyzer
+-------------------
+
+Scans Alembic migrations for schema impacts.
+
+Dependencies
+~~~~~~~~~~~~
+
+* ``Alembic``
+
+Enable or disable
+~~~~~~~~~~~~~~~~~
+
+Configure ``[migrations]`` paths and enable the analyzer:
+
+.. code-block:: toml
+
+   [analyzers]
+   migrations = true  # set to false to disable
+
+   [migrations]
+   paths = ["migrations"]
+
+Severity rules
+~~~~~~~~~~~~~~
+
+* Dropped column → major
+* Added non-nullable column without default → major
+* Added column → minor
+* Added index → minor
+
+Detectable change
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: diff
+
+   @@
+   def upgrade():
+   -    pass
+   +    op.add_column("users", sa.Column("email", sa.String(), nullable=False))
+
+Example output
+~~~~~~~~~~~~~~
+
+::
+
+   - [MAJOR] migrations/20240401_add_email.py: Added non-nullable column


### PR DESCRIPTION
## Summary
- document configuration, severity rules, and dependencies for CLI, web route, and migrations analyzers
- add example code snippets and typical analyzer output

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only docs/analyzers.rst -v`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f339fadf4832299dd3c6332b28bc5