### PR TITLE
feat(cli): skip redundant version bumps

### DIFF
--- a/bumpwright/compare.py
+++ b/bumpwright/compare.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .public_api import FuncSig, Param, PublicAPI
 
@@ -128,16 +128,19 @@ def diff_public_api(
     return impacts
 
 
-def decide_bump(impacts: List[Impact]) -> str:
+def decide_bump(impacts: List[Impact]) -> Optional[str]:
     """Determine the bump level from a list of impacts.
 
     Args:
         impacts: Detected impacts from API comparison.
 
     Returns:
-        Suggested semantic version bump (``"major"``, ``"minor"``, or ``"patch"``).
+        Suggested semantic version bump (``"major"``, ``"minor"``, or ``"patch"``) or
+        ``None`` if ``impacts`` is empty.
     """
 
+    if not impacts:
+        return None
     if any(i.severity == "major" for i in impacts):
         return "major"
     if any(i.severity == "minor" for i in impacts):

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -135,3 +135,60 @@ def test_bump_command_searches_pyproject(tmp_path: Path) -> None:
     )
     assert "Bumped version: 0.1.0 -> 0.1.1 (patch)" in res.stdout
     assert read_project_version(repo / "pyproject.toml") == "0.1.1"
+
+
+def test_bump_command_skips_when_no_changes(tmp_path: Path) -> None:
+    repo, pkg, base = _setup_repo(tmp_path)
+
+    (pkg / "extra.py").write_text("def bar() -> int:\n    return 2\n", encoding="utf-8")
+    _run(["git", "add", "pkg/extra.py"], repo)
+    _run(["git", "commit", "-m", "feat: add bar"], repo)
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--base",
+            base,
+            "--head",
+            "HEAD",
+            "--pyproject",
+            "pyproject.toml",
+            "--commit",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    assert read_project_version(repo / "pyproject.toml") == "0.2.0"
+
+    prev = _run(["git", "rev-parse", "HEAD^"], repo)
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--base",
+            prev,
+            "--head",
+            "HEAD",
+            "--pyproject",
+            "pyproject.toml",
+            "--commit",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    assert "No version bump needed" in res.stdout
+    assert read_project_version(repo / "pyproject.toml") == "0.2.0"


### PR DESCRIPTION
## Summary
- avoid applying version bumps when no relevant files changed
- detect absence of API impacts and skip bumping
- test bump command to ensure repeated runs are skipped

## Testing
- `ruff check bumpwright/cli.py bumpwright/compare.py tests/test_cli_auto.py --fix`
- `isort bumpwright/cli.py bumpwright/compare.py tests/test_cli_auto.py`
- `black bumpwright/cli.py bumpwright/compare.py tests/test_cli_auto.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f33b0c30883229fd3a0bf1d99c89f