### PR TITLE
docs(docs): refresh docs in UK English

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Keep your project's version numbers honest by inspecting public interfaces and
 recommending the next semantic version. It can even apply the bump for you.
 
-## Why semverbump
+## Why Bumpwright
 
 Semantic versioning only works when releases accurately reflect the impact of
 code changes. Manually tracking public interfaces across a project is tedious
-and error-prone. **semverbump** automates this process by scanning source code
+and error-prone. **Bumpwright** automates this process by scanning source code
 for API changes and recommending the appropriate version bump.
 
 Design goals include:
@@ -23,6 +23,8 @@ Design goals include:
 - Static diff of the public API to highlight breaking changes.
 - Pluggable analysers for command-line tools, web routes and database
   migrations.
+- Dry-run mode to preview version bumps without touching any files.
+- Output in plain text, Markdown or JSON for easy integration.
 - Optional helpers to update version numbers across common files and tag the release.
 
 ## Installation
@@ -49,22 +51,22 @@ pip install bumpwright
 2. **Suggest the next version** between two git references:
 
    ```console
-   $ semverbump decide --base origin/main --head HEAD --format text
-   semverbump suggests: minor
+   $ bumpwright decide --base origin/main --head HEAD --format text
+   bumpwright suggests: minor
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```
 
    ```console
-   $ semverbump decide --base origin/main --head HEAD --format md
-   **semverbump** suggests: `minor`
+   $ bumpwright decide --base origin/main --head HEAD --format md
+   **bumpwright** suggests: `minor`
 
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```
 
    ```console
-   $ semverbump decide --base origin/main --head HEAD --format json
+   $ bumpwright decide --base origin/main --head HEAD --format json
    {"level": "minor", "changes": [{"severity": "minor", "symbol": "cli.new_command", "description": "added CLI entry 'greet'"}]}
    ```
 
@@ -84,8 +86,8 @@ pip install bumpwright
 4. **Run everything in one step** with automatic bumping and tagging:
 
    ```console
-   $ semverbump auto --base origin/main --commit --tag --pyproject pyproject.toml
-   **semverbump** suggests: `minor`
+   $ bumpwright auto --base origin/main --commit --tag --pyproject pyproject.toml
+   **bumpwright** suggests: `minor`
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    Bumped version: 1.2.3 -> 1.3.0 (minor)

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -12,7 +12,7 @@ abbr {
     vertical-align: baseline;
     border-radius: 0.25rem;
     color: #fff;
-    background-color: #d77d7d; /* Bootstrap danger color for reference */
+    background-color: #d77d7d; /* Bootstrap danger colour for reference */
     border: 1px solid transparent;
     text-decoration: none;
 }

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,7 +1,7 @@
 Advanced Usage
 ==============
 
-Customize rules for version decisions:
+Customise rules for version decisions:
 
 .. code-block:: toml
 
@@ -79,7 +79,7 @@ Handling multi-package repositories
 
       Updated packages/pkg_a/pyproject.toml from 0.4.1 to 0.5.0
 
-Custom severity mapping and plugin analyzers
+Custom severity mapping and plugin analysers
 --------------------------------------------
 
 1. Create a plugin that reports ``print`` usage:
@@ -112,7 +112,7 @@ Custom severity mapping and plugin analyzers
       [rules]
       print_call = "patch"
 
-3. Execute the analyzer:
+3. Execute the analyser:
 
    .. code-block:: console
 

--- a/docs/analysers.rst
+++ b/docs/analysers.rst
@@ -1,7 +1,7 @@
-Additional Analyzers
+Additional Analysers
 ====================
 
-Enable optional analyzers in ``bumpwright.toml``:
+Enable optional analysers in ``bumpwright.toml``:
 
 .. code-block:: toml
 
@@ -13,7 +13,7 @@ Enable optional analyzers in ``bumpwright.toml``:
    [migrations]
    paths = ["migrations"]
 
-CLI Analyzer
+CLI Analyser
 ------------
 
 Tracks ``argparse`` or ``click`` command-line interfaces.
@@ -21,16 +21,16 @@ Tracks ``argparse`` or ``click`` command-line interfaces.
 Dependencies
 ~~~~~~~~~~~~
 
-* ``click`` (optional for click-based CLIs)
+* ``click`` (optional for Click-based CLIs)
 
 Enable or disable
 ~~~~~~~~~~~~~~~~~
 
-Set ``cli`` under ``[analyzers]`` to ``true`` or ``false``.
+Set ``cli`` under ``[analysers]`` to ``true`` or ``false``.
 
 .. code-block:: toml
 
-   [analyzers]
+   [analysers]
    cli = true  # set to false to disable
 
 Severity rules
@@ -66,7 +66,7 @@ Example output
 
    - [MAJOR] greet: Added required option '--force'
 
-Web Route Analyzer
+Web Route Analyser
 ------------------
 
 Detects HTTP route changes in Flask or FastAPI apps.
@@ -79,11 +79,11 @@ Dependencies
 Enable or disable
 ~~~~~~~~~~~~~~~~~
 
-Set ``web_routes`` under ``[analyzers]``.
+Set ``web_routes`` under ``[analysers]``.
 
 .. code-block:: toml
 
-   [analyzers]
+   [analysers]
    web_routes = true  # set to false to disable
 
 Severity rules
@@ -117,7 +117,7 @@ Example output
 
    - [MINOR] GET /users/{user_id}: Added optional param 'verbose'
 
-Migrations Analyzer
+Migrations Analyser
 -------------------
 
 Scans Alembic migrations for schema impacts.
@@ -130,11 +130,11 @@ Dependencies
 Enable or disable
 ~~~~~~~~~~~~~~~~~
 
-Configure ``[migrations]`` paths and enable the analyzer:
+Configure ``[migrations]`` paths and enable the analyser:
 
 .. code-block:: toml
 
-   [analyzers]
+   [analysers]
    migrations = true  # set to false to disable
 
    [migrations]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ napoleon_include_special_with_doc = True
 napoleon_use_param = True
 napoleon_use_rtype = True
 
-# Autodoc / typehints behavior
+# Autodoc / typehints behaviour
 autodoc_default_options = {
     "members": True,
     "inherited-members": True,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,4 +23,4 @@ sections with defaults shown:
    [migrations]
    paths = ["migrations"]
 
-Enable an analyzer by setting its value to ``true`` under ``[analyzers]``.
+Enable an analyser by setting its value to ``true`` under ``[analyzers]``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Static public-API diff and heuristics to suggest semantic version bumps.
 
    installation
    usage
-   analyzers
+   analysers
    advanced
    configuration
    troubleshooting

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,8 +7,8 @@ Install ``bumpwright`` from PyPI:
 
    pip install bumpwright
 
-Optional analyzers may require extra dependencies:
+Optional analysers may require extra dependencies:
 
-- ``click`` for the CLI analyzer
-- ``flask`` or ``fastapi`` for the web route analyzer
-- ``alembic`` for the migrations analyzer
+- ``click`` for the CLI analyser
+- ``flask`` or ``fastapi`` for the web route analyser
+- ``alembic`` for the migrations analyser

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -4,7 +4,7 @@ Roadmap
 The following items outline potential directions for improving
 ``bumpwright``. Contributions and discussion are welcome.
 
-Upcoming analyzers
+Upcoming analysers
 ------------------
 
 * GraphQL schema diffing
@@ -14,7 +14,7 @@ Upcoming analyzers
 Ecosystem enhancements
 ----------------------
 
-* Pluggable analyzer API so projects can ship custom rules
+* Pluggable analyser API so projects can ship custom rules
 * User-defined severity mappings and thresholds
 * Machine-readable (JSON) and rich HTML reports
 * Official helpers for common CI providers

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,7 +1,7 @@
 Troubleshooting
 ===============
 
-- **No analyzers run**: ensure desired analyzers are enabled in
+- **No analysers run**: ensure desired analysers are enabled in
   ``bumpwright.toml`` and required dependencies are installed.
 - **Configuration not found**: pass ``--config`` to specify the file location.
 - **Git errors**: run commands inside a git repository with accessible refs.


### PR DESCRIPTION
## Summary
- polish README and docs with UK English wording and updated examples
- replace outdated `semverbump` references and highlight new features

## Testing
- `ruff check . --fix`
- `isort --check --verbose docs/conf.py`
- `black docs/conf.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f36bb157c83229e9ed0c976dcbb33