### PR TITLE
fix(cli): ignore release commit for subsequent bumps

### DIFF
--- a/bumpwright/gitutils.py
+++ b/bumpwright/gitutils.py
@@ -108,3 +108,23 @@ def read_file_at_ref(ref: str, path: str, cwd: str | None = None) -> Optional[st
         return _run(["git", "show", f"{ref}:{path}"], cwd)
     except subprocess.CalledProcessError:
         return None
+
+
+def last_release_commit(cwd: str | None = None) -> Optional[str]:
+    """Return the most recent release commit created by bumpwright.
+
+    Args:
+        cwd: Repository path to inspect.
+
+    Returns:
+        Hash of the latest ``chore(release):`` commit or ``None`` if not found.
+    """
+
+    try:
+        out = _run(
+            ["git", "log", "-n", "1", "--grep", "^chore(release):", "--format=%H"],
+            cwd,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return out.strip() or None

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -168,6 +168,59 @@ def test_bump_command_skips_when_no_changes(tmp_path: Path) -> None:
 
     assert read_project_version(repo / "pyproject.toml") == "0.2.0"
 
+
+def test_auto_ignores_release_commit(tmp_path: Path) -> None:
+    repo, pkg, _ = _setup_repo(tmp_path)
+
+    remote = tmp_path / "remote.git"
+    _run(["git", "init", "--bare", str(remote)], tmp_path)
+    _run(["git", "remote", "add", "origin", str(remote)], repo)
+    _run(["git", "branch", "-M", "main"], repo)
+    _run(["git", "push", "-u", "origin", "main"], repo)
+
+    (pkg / "extra.py").write_text("def bar() -> int:\n    return 2\n", encoding="utf-8")
+    _run(["git", "add", "pkg/extra.py"], repo)
+    _run(["git", "commit", "-m", "feat: add bar"], repo)
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "auto",
+            "--pyproject",
+            "pyproject.toml",
+            "--commit",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    assert read_project_version(repo / "pyproject.toml") == "0.2.0"
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "auto",
+            "--pyproject",
+            "pyproject.toml",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    assert "No version bump needed" in res.stdout
+    assert read_project_version(repo / "pyproject.toml") == "0.2.0"
+
     prev = _run(["git", "rev-parse", "HEAD^"], repo)
     res = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- skip version bump if last commit is a release commit
- add regression test for repeated auto run

## Testing
- `ruff check --fix bumpwright/gitutils.py bumpwright/cli.py tests/test_cli_auto.py`
- `black bumpwright/gitutils.py bumpwright/cli.py tests/test_cli_auto.py`
- `isort bumpwright/gitutils.py bumpwright/cli.py tests/test_cli_auto.py`
- `pytest`

## Labels
- fix

------
https://chatgpt.com/codex/tasks/task_e_689f36f0a8d08322861ce53108e1f50c