### PR TITLE
feat(analyzers): add registry metadata and info retrieval

### DIFF
--- a/bumpwright/analyzers/__init__.py
+++ b/bumpwright/analyzers/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, List, Protocol, Type
 
 from ..compare import Impact
@@ -11,8 +12,9 @@ from ..config import Config
 class Analyzer(Protocol):
     """Protocol for analyzer plugins.
 
-    An analyzer collects state for a given git reference and compares two
-    states to produce :class:`Impact` entries.
+    Analyzer implementations capture domain-specific state for a git
+    reference and compare two such states to generate :class:`Impact`
+    entries describing any public API changes.
     """
 
     def __init__(self, cfg: Config) -> None:
@@ -25,32 +27,74 @@ class Analyzer(Protocol):
         """Compare two states and return impacts."""
 
 
-REGISTRY: Dict[str, Type[Analyzer]] = {}
+@dataclass(frozen=True)
+class AnalyzerInfo:
+    """Metadata describing a registered analyzer.
+
+    Attributes:
+        name: Unique identifier for the analyzer.
+        cls: Implementation class used to instantiate the analyzer.
+        description: Human-readable description of the analyzer.
+    """
+
+    name: str
+    cls: Type[Analyzer]
+    description: str
 
 
-def register(name: str):
-    """Decorator registering an analyzer implementation."""
+REGISTRY: Dict[str, AnalyzerInfo] = {}
+
+
+def register(name: str, description: str | None = None):
+    """Decorator registering an analyzer implementation.
+
+    Args:
+        name: Registry key used to enable the analyzer via configuration.
+        description: Optional human-readable description. Defaults to the
+            analyzer class's docstring.
+
+    Returns:
+        Decorator that registers the analyzer class.
+    """
 
     def _wrap(cls: Type[Analyzer]) -> Type[Analyzer]:
-        REGISTRY[name] = cls
+        desc = description or (cls.__doc__ or "").strip()
+        REGISTRY[name] = AnalyzerInfo(name=name, cls=cls, description=desc)
         return cls
 
     return _wrap
 
 
 def load_enabled(cfg: Config) -> List[Analyzer]:
-    """Instantiate analyzers enabled via configuration."""
+    """Instantiate analyzers enabled via configuration.
+
+    Args:
+        cfg: Global configuration object.
+
+    Returns:
+        List of instantiated analyzers.
+
+    Raises:
+        ValueError: If a configured analyzer name is not registered.
+    """
+
     out: List[Analyzer] = []
     for name in cfg.analyzers.enabled:
-        cls = REGISTRY.get(name)
-        if cls:
-            out.append(cls(cfg))
+        info = REGISTRY.get(name)
+        if info is None:
+            raise ValueError(f"Analyzer '{name}' is not registered")
+        out.append(info.cls(cfg))
     return out
 
 
 def available() -> List[str]:
     """Return names of all registered analyzers."""
     return sorted(REGISTRY.keys())
+
+
+def get_analyzer_info(name: str) -> AnalyzerInfo | None:
+    """Return registry information for ``name`` if available."""
+    return REGISTRY.get(name)
 
 
 # Import built-in analyzers for registration side-effects
@@ -62,7 +106,9 @@ from . import cli, web_routes  # noqa: F401,E402  # pylint: disable=wrong-import
 
 __all__ = [
     "Analyzer",
+    "AnalyzerInfo",
     "register",
     "load_enabled",
     "available",
+    "get_analyzer_info",
 ]

--- a/bumpwright/analyzers/cli.py
+++ b/bumpwright/analyzers/cli.py
@@ -187,7 +187,7 @@ def _build_cli_at_ref(
     return out
 
 
-@register("cli")
+@register("cli", "Analyze command-line interfaces for changes.")
 class CLIAnalyzer:
     """Analyzer plugin for command-line interfaces."""
 

--- a/bumpwright/analyzers/web_routes.py
+++ b/bumpwright/analyzers/web_routes.py
@@ -149,7 +149,7 @@ def diff_routes(
     return impacts
 
 
-@register("web_routes")
+@register("web_routes", "Track changes in web application routes.")
 class WebRoutesAnalyzer:
     """Analyzer plugin for web application routes."""
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -89,7 +89,7 @@ Custom severity mapping and plugin analysers
       from bumpwright.analyzers import Analyzer, register
       from bumpwright.compare import Impact
 
-      @register("no_prints")
+      @register("no_prints", "Report usage of print statements")
       class NoPrints(Analyzer):
           def __init__(self, cfg):
               self.severity = getattr(cfg.rules, "print_call", "patch")
@@ -101,6 +101,9 @@ Custom severity mapping and plugin analysers
               if "print(" in new and "print(" not in old:
                   return [Impact(self.severity, "example.py", "Added print call")]
               return []
+
+   The optional description makes the plugin discoverable via
+   ``get_analyzer_info("no_prints")`` and the :func:`available` helper.
 
 2. Enable the plugin and map its finding to a version bump:
 

--- a/tests/test_analyzer_registry.py
+++ b/tests/test_analyzer_registry.py
@@ -1,0 +1,46 @@
+import pytest
+
+from bumpwright.analyzers import (
+    Analyzer,
+    available,
+    get_analyzer_info,
+    load_enabled,
+    register,
+)
+from bumpwright.compare import Impact
+from bumpwright.config import Config
+
+
+def test_register_records_metadata(monkeypatch) -> None:
+    """Ensure register stores class and description."""
+    from bumpwright import analyzers
+
+    monkeypatch.setattr(analyzers, "REGISTRY", {})
+
+    @register("dummy", "Example analyzer")
+    class DummyAnalyzer(Analyzer):
+        def __init__(self, cfg: Config) -> None:  # pragma: no cover - simple init
+            self.cfg = cfg
+
+        def collect(self, ref: str) -> object:  # pragma: no cover - trivial
+            return {}
+
+        def compare(
+            self, old: object, new: object
+        ) -> list[Impact]:  # pragma: no cover - trivial
+            return []
+
+    assert "dummy" in available()
+    info = get_analyzer_info("dummy")
+    assert info and info.description == "Example analyzer"
+
+
+def test_load_enabled_errors_for_unknown(monkeypatch) -> None:
+    """Unknown analyzers should raise a clear error."""
+    from bumpwright import analyzers
+
+    monkeypatch.setattr(analyzers, "REGISTRY", {})
+    cfg = Config()
+    cfg.analyzers.enabled.add("missing")
+    with pytest.raises(ValueError):
+        load_enabled(cfg)


### PR DESCRIPTION
## Summary
- enrich analyzer registry with `AnalyzerInfo` metadata and description-aware registration
- expose `get_analyzer_info` helper and validate enabled analyzers
- document analyzer descriptions and add tests for registry handling

## Testing
- `ruff check bumpwright/analyzers/__init__.py bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py tests/test_analyzer_registry.py`
- `black bumpwright/analyzers/__init__.py bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py tests/test_analyzer_registry.py`
- `isort bumpwright/analyzers/__init__.py`
- `isort bumpwright/analyzers/cli.py`
- `isort bumpwright/analyzers/web_routes.py`
- `isort tests/test_analyzer_registry.py`
- `pytest`

Labels: feat

------
https://chatgpt.com/codex/tasks/task_e_689f427e7524832290796e2aba422ff4