### PR TITLE
feat(cli): add format option to bump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install bumpwright
 | Subcommand | Purpose | Key options |
 |------------|---------|-------------|
 | `decide`   | Recommend a bump between two references | `--base`, `--head`, `--format` |
-| `bump`     | Apply a specific version bump | `--level`, `--pyproject`, `--commit`, `--tag` |
+| `bump`     | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
 | `auto`     | Decide and bump in a single step | `--base`, `--head`, `--commit`, `--tag` |
 
 1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:

--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -262,6 +262,15 @@ def bump_command(args: argparse.Namespace) -> int:
         $ bumpwright bump --dry-run
         Bumped version: 1.2.3 -> 1.2.4 (patch)
 
+        Emit JSON for automation:
+
+        $ bumpwright bump --dry-run --format json
+        {
+          "old_version": "1.2.3",
+          "new_version": "1.2.4",
+          "level": "patch"
+        }
+
         Apply an explicit minor bump and create a commit:
 
         $ bumpwright bump --level minor --commit
@@ -325,7 +334,21 @@ def bump_command(args: argparse.Namespace) -> int:
         paths=paths,
         ignore=ignore,
     )
-    print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "old_version": vc.old,
+                    "new_version": vc.new,
+                    "level": vc.level,
+                },
+                indent=2,
+            )
+        )
+    elif args.format == "md":
+        print(f"Bumped version: `{vc.old}` -> `{vc.new}` ({vc.level})")
+    else:
+        print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
     if not args.dry_run:
         _commit_tag(str(pyproject), vc.new, args.commit, args.tag)
     return 0
@@ -508,6 +531,12 @@ def main(argv: list[str] | None = None) -> int:
         "--head",
         default="HEAD",
         help="Head git reference; defaults to the current HEAD.",
+    )
+    p_bump.add_argument(
+        "--format",
+        choices=["text", "md", "json"],
+        default="text",
+        help="Output style: plain text, Markdown, or machine-readable JSON.",
     )
     p_bump.add_argument(
         "--pyproject",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,6 +87,10 @@ Update version information in ``pyproject.toml`` and other files.
 ``--head HEAD``
     Head git reference. Defaults to ``HEAD``.
 
+``--format {text,md,json}``
+    Output style. ``text`` prints plain console output, ``md`` emits Markdown,
+    and ``json`` produces machine-readable data. Defaults to ``text``.
+
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to
     ``pyproject.toml``.

--- a/tests/test_cli_bump_format.py
+++ b/tests/test_cli_bump_format.py
@@ -1,0 +1,37 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.test_cli_auto import _setup_repo
+
+
+def test_bump_command_json_format(tmp_path: Path) -> None:
+    """Ensure bump emits machine-readable JSON when requested."""
+    repo, _, _ = _setup_repo(tmp_path)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "minor",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    data = json.loads(res.stdout)
+    assert data["old_version"] == "0.1.0"
+    assert data["new_version"] == "0.2.0"
+    assert data["level"] == "minor"


### PR DESCRIPTION
## Summary
- allow specifying output format for `bump` command
- document new `--format` option
- test JSON output for `bump`

## Testing
- `isort bumpwright/cli.py tests/test_cli_bump_format.py`
- `black bumpwright/cli.py tests/test_cli_bump_format.py`
- `ruff check bumpwright/cli.py tests/test_cli_bump_format.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f437f4bb08322bb2c279e4f70cd37