### PR TITLE
fix(cli): align default base with decide

### DIFF
--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -194,8 +194,8 @@ def decide_command(args: argparse.Namespace) -> int:
         Process exit code.
 
     Examples:
-        Compare the current commit to its parent (default ``--base`` is
-        ``HEAD^``) and display Markdown output:
+        Compare the current commit to its parent (default ``--base`` is the last
+        release commit or ``HEAD^``) and display Markdown output:
 
         $ bumpwright decide --format md
         **bumpwright** suggests: `patch`
@@ -247,8 +247,8 @@ def bump_command(args: argparse.Namespace) -> int:
     """CLI command to apply a version bump.
 
     If ``--level`` is not specified, the bump level is inferred by comparing
-    ``--base`` (defaults to the upstream of ``HEAD``) and ``--head`` (defaults
-    to ``HEAD``).
+    ``--base`` (defaults to the last release commit or the previous commit
+    ``HEAD^``) and ``--head`` (defaults to ``HEAD``).
 
     Args:
         args: Parsed command-line arguments.
@@ -257,7 +257,7 @@ def bump_command(args: argparse.Namespace) -> int:
         Process exit code.
 
     Examples:
-        Dry-run the inferred bump against the upstream branch:
+        Dry-run the inferred bump against the previous commit:
 
         $ bumpwright bump --dry-run
         Bumped version: 1.2.3 -> 1.2.4 (patch)
@@ -289,7 +289,7 @@ def bump_command(args: argparse.Namespace) -> int:
     elif level:
         base = "HEAD^"
     else:
-        base = last_release_commit() or _infer_base_ref()
+        base = last_release_commit() or "HEAD^"
     head = args.head
 
     try:
@@ -385,9 +385,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_decide.add_argument(
         "--base",
-        default="HEAD^",
         help=(
-            "Base git reference to compare against. Defaults to the previous commit (HEAD^)."
+            "Base git reference to compare against. Defaults to the last release commit "
+            "or the previous commit (HEAD^)."
         ),
     )
     p_decide.add_argument(
@@ -415,7 +415,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_bump.add_argument(
         "--base",
-        help="Base git reference when auto-deciding the level (uses upstream of HEAD by default).",
+        help=(
+            "Base git reference when auto-deciding the level. Defaults to the last release "
+            "commit or the previous commit (HEAD^)."
+        ),
     )
     p_bump.add_argument(
         "--head",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,9 @@ Usage
 =====
 
 The ``bumpwright`` command-line interface provides two subcommands to help
-manage project versions based on public API changes. This section explains each
+manage project versions based on public API changes. By default, both
+subcommands compare the current commit against the last release commit, or the
+previous commit (``HEAD^``) when no release exists. This section explains each
 command, its arguments, and expected outputs.
 
 Global options
@@ -21,7 +23,8 @@ Compare two git references and report the semantic version level they require.
 
 ``--base BASE``
     Base git reference to compare against, for example ``origin/main``.
-    Defaults to the previous commit (``HEAD^``).
+    Defaults to the last release commit if available, otherwise the previous
+    commit (``HEAD^``).
 
 ``--head HEAD``
     Head git reference. Defaults to ``HEAD``.
@@ -47,8 +50,8 @@ Compare two git references and report the semantic version level they require.
    }
 
 Running ``bumpwright decide`` without ``--base`` compares the current commit
-against its parent (``HEAD^``). Because this subcommand only inspects commits,
-there is no ``--dry-run`` flag.
+against the last release commit or, if none exists, its parent (``HEAD^``).
+Because this subcommand only inspects commits, there is no ``--dry-run`` flag.
 
 .. code-block:: console
 
@@ -81,8 +84,8 @@ Update version information in ``pyproject.toml`` and other files.
     determine the level automatically.
 
 ``--base BASE``
-    Base git reference when auto-deciding the level. Defaults to the current
-    branch's upstream.
+    Base git reference when auto-deciding the level. Defaults to the last
+    release commit if available, otherwise the previous commit (``HEAD^``).
 
 ``--head HEAD``
     Head git reference. Defaults to ``HEAD``.
@@ -135,8 +138,9 @@ Update version information in ``pyproject.toml`` and other files.
    bumpwright bump --level minor --pyproject pyproject.toml --commit --tag
 
 This prints the old and new versions and, when ``--commit`` and ``--tag`` are
-set, commits and tags the release. Omitting ``--base`` uses the branch's
-upstream, and omitting ``--head`` assumes ``HEAD``.
+set, commits and tags the release. Omitting ``--base`` compares against the
+last release commit or the previous commit (``HEAD^``), and omitting
+``--head`` assumes ``HEAD``.
 
 To preview changes without touching the filesystem, combine ``--dry-run`` with
 JSON output:
@@ -153,8 +157,8 @@ JSON output:
      "level": "patch"
    }
 
-Omitting ``--base`` compares against the branch's upstream; leaving out
-``--head`` uses the current ``HEAD``.
+Omitting ``--base`` compares against the last release commit or the previous
+commit (``HEAD^``); leaving out ``--head`` uses the current ``HEAD``.
 
 
 Full workflow
@@ -180,10 +184,6 @@ Common errors
 ``pyproject.toml`` not found
     Ensure you run the command at the project root or pass ``--pyproject`` with
     the correct path.
-
-No upstream configured for base
-    When ``--base`` is omitted, the upstream branch is used. Configure an
-    upstream with ``git push -u origin HEAD`` or provide ``--base`` explicitly.
 
 Changes not applied after running
     The ``--dry-run`` flag previews the bump without touching files. Remove it

--- a/tests/test_cli_bump_decide_parity.py
+++ b/tests/test_cli_bump_decide_parity.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.cli_helpers import run, setup_repo
+
+
+def test_bump_and_decide_agree_on_no_api_changes(tmp_path: Path) -> None:
+    """bump and decide should both detect no bump when API is unchanged."""
+    repo, pkg, _ = setup_repo(tmp_path)
+
+    # Modify implementation without changing the public API.
+    init_file = pkg / "__init__.py"
+    init_file.write_text(
+        "def foo() -> int:\n    # no-op change\n    return 1\n", encoding="utf-8"
+    )
+    run(["git", "add", "pkg/__init__.py"], repo)
+    run(["git", "commit", "-m", "chore: comment"], repo)
+
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+
+    res_decide = subprocess.run(
+        [sys.executable, "-m", "bumpwright.cli", "decide"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert "Suggested bump: None" in res_decide.stdout
+
+    res_bump = subprocess.run(
+        [sys.executable, "-m", "bumpwright.cli", "bump"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert "No version bump needed" in res_bump.stdout


### PR DESCRIPTION
## Summary
- fallback to last release commit or HEAD^ when bump infers base
- document default comparison behaviour for decide and bump
- ensure bump and decide agree when API unchanged

## Testing
- `ruff check bumpwright/cli.py tests/test_cli_bump_decide_parity.py --fix`
- `isort bumpwright/cli.py tests/test_cli_bump_decide_parity.py`
- `black bumpwright/cli.py tests/test_cli_bump_decide_parity.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f47f8d9f08322a786556763a79a7d