### PR TITLE
docs(configuration): document all configuration sections and defaults

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,8 +1,10 @@
 Configuration
 =============
 
-``bumpwright`` reads settings from ``bumpwright.toml``. The file supports these
-sections with defaults shown:
+``bumpwright`` reads settings from ``bumpwright.toml``. If the file is missing
+or a section is omitted, built-in defaults are used.
+
+Example configuration showing all available sections and their default values:
 
 .. code-block:: toml
 
@@ -19,8 +21,130 @@ sections with defaults shown:
 
    [analyzers]
    cli = false
+   web_routes = false
 
    [migrations]
    paths = ["migrations"]
 
-Enable an analyser by setting its value to ``true`` under ``[analyzers]``.
+   [version]
+   paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]
+   ignore = []
+
+Set an analyzer value to ``true`` to enable it.
+
+Sections
+--------
+
+Project
+~~~~~~~
+
+.. list-table:: Project options
+   :header-rows: 1
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``package``
+     - str
+     - ``""``
+     - Importable package containing the project's code. When empty the
+       repository layout is used.
+   * - ``public_roots``
+     - list[str]
+     - ``["."]``
+     - Paths whose contents constitute the public API.
+   * - ``index_file``
+     - str
+     - ``"pyproject.toml"``
+     - File containing project metadata used for version discovery.
+
+Ignore
+~~~~~~
+
+.. list-table:: Ignore options
+   :header-rows: 1
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``paths``
+     - list[str]
+     - ``["tests/**", "examples/**", "scripts/**"]``
+     - Glob patterns excluded from analysis.
+
+Rules
+~~~~~
+
+.. list-table:: Rule options
+   :header-rows: 1
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``return_type_change``
+     - ``"minor"`` | ``"major"``
+     - ``"minor"``
+     - Version bump level when a function's return type changes.
+
+Analyzers
+~~~~~~~~~
+
+Each key under ``[analyzers]`` toggles a plugin. Unknown names raise an error
+at runtime. Built-in analyzers include:
+
+.. list-table:: Available analyzers
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Default
+   * - ``cli``
+     - Detects changes to command-line interfaces implemented with
+       ``argparse`` or ``click``.
+     - ``false``
+   * - ``web_routes``
+     - Tracks additions or removals of web routes in frameworks such as
+       Flask or FastAPI.
+     - ``false``
+
+Migrations
+~~~~~~~~~~
+
+.. list-table:: Migration options
+   :header-rows: 1
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``paths``
+     - list[str]
+     - ``["migrations"]``
+     - Directories containing Alembic migration scripts to inspect.
+
+Version
+~~~~~~~
+
+Controls where version strings are read and updated.
+
+.. list-table:: Version options
+   :header-rows: 1
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``paths``
+     - list[str]
+     - ``["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]``
+     - Glob patterns scanned for version declarations.
+   * - ``ignore``
+     - list[str]
+     - ``[]``
+     - Glob patterns excluded from version replacement.
+
+All sections and keys are optional; unspecified values fall back to the
+defaults shown above.


### PR DESCRIPTION
## Summary
- expand configuration guide with explanations of every section
- document available analyzers and version file settings

## Testing
- `ruff check .`
- `black .`
- `isort --check .` *(fails: imports are incorrectly sorted in existing files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4a059330832299bbd0d57964f92b