### PR TITLE
feat(cli): link commit hashes in markdown output

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,6 +14,10 @@ Global options
     Path to the configuration file. Defaults to ``bumpwright.toml`` in the
     current working directory.
 
+``--repo-url URL``
+    Base URL of the repository. When combined with ``--format md``, any commit
+    hashes in the output are rendered as links to ``{URL}/commit/{hash}``.
+
 ``decide`` – suggest a bump
 ---------------------------
 
@@ -71,6 +75,16 @@ Omitting ``--head`` uses the current ``HEAD``:
 .. code-block:: console
 
    bumpwright decide --base origin/main --format json
+
+Supplying ``--repo-url`` with Markdown output converts commit hashes into links:
+
+.. code-block:: console
+
+   bumpwright decide --format md --repo-url https://github.com/example/repo
+
+.. code-block:: text
+
+   - [MINOR] cli.new_command: added feature from [0123abcd](https://github.com/example/repo/commit/0123abcd)
 
 ``bump`` – apply a bump
 -----------------------

--- a/tests/test_repo_url.py
+++ b/tests/test_repo_url.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+from pathlib import Path
+
+from bumpwright.cli import decide_command
+from bumpwright.compare import Impact
+from tests.cli_helpers import setup_repo
+
+
+def test_repo_url_links_commits(tmp_path: Path, monkeypatch, capsys) -> None:
+    repo, _pkg, base = setup_repo(tmp_path)
+    commit_hash = base
+
+    # Avoid real git interactions in decide_command
+    monkeypatch.setattr("bumpwright.cli._build_api_at_ref", lambda *a, **k: {})
+    monkeypatch.setattr("bumpwright.cli.diff_public_api", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "bumpwright.cli._run_analyzers",
+        lambda *a, **k: [Impact("minor", "sym", f"ref {commit_hash}")],
+    )
+
+    args = argparse.Namespace(
+        config="bumpwright.toml",
+        base=base,
+        head="HEAD",
+        format="md",
+        repo_url="https://github.com/example/repo",
+    )
+
+    old_cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        decide_command(args)
+    finally:
+        os.chdir(old_cwd)
+
+    output = capsys.readouterr().out
+    link = f"[{commit_hash}](https://github.com/example/repo/commit/{commit_hash})"
+    assert link in output


### PR DESCRIPTION
## Summary
- allow specifying a repository base URL via `--repo-url`
- link commit hashes to the repo when using Markdown output
- document the `--repo-url` option with examples

## Testing
- `ruff check bumpwright tests`
- `isort bumpwright/cli.py tests/test_repo_url.py`
- `black bumpwright/cli.py tests/test_repo_url.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4b95800883229688c8ad4e0d3ac7