### PR TITLE
feat(version): update version bump to scan multiple files

### DIFF
--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -17,7 +17,7 @@ _DEFAULTS = {
     "analyzers": {"cli": False},
     "migrations": {"paths": ["migrations"]},
     "version": {
-        "paths": ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"],
+        "paths": ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py"],
         "ignore": [],
     },
 }
@@ -76,7 +76,12 @@ class VersionFiles:
     """
 
     paths: List[str] = field(
-        default_factory=lambda: ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]
+        default_factory=lambda: [
+            "pyproject.toml",
+            "setup.py",
+            "setup.cfg",
+            "**/__init__.py",
+        ]
     )
     ignore: List[str] = field(default_factory=list)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,6 +76,10 @@ Omitting ``--head`` uses the current ``HEAD``:
 -----------------------
 
 Update version information in ``pyproject.toml`` and other files.
+By default, ``bumpwright`` also searches ``setup.py`` and any ``__init__.py``
+files for a ``__version__`` variable. These locations can be customised via the
+``[version]`` section in ``bumpwright.toml`` or overridden with
+``--version-path``/``--version-ignore``.
 
 **Arguments**
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -37,11 +37,7 @@ def test_apply_bump_updates_extra_files(tmp_path: Path) -> None:
     init = pkg / "__init__.py"
     init.write_text("__version__ = '0.1.0'", encoding="utf-8")
 
-    out = apply_bump(
-        "patch",
-        py,
-        paths=[str(py), str(setup), str(init)],
-    )
+    out = apply_bump("patch", py)
     assert out.new == "0.1.1"
     assert "version='0.1.1'" in setup.read_text(encoding="utf-8")
     assert "__version__ = '0.1.1'" in init.read_text(encoding="utf-8")
@@ -50,13 +46,10 @@ def test_apply_bump_updates_extra_files(tmp_path: Path) -> None:
 def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
     py = tmp_path / "pyproject.toml"
     py.write_text(toml_dumps({"project": {"version": "1.0.0"}}))
-    other = tmp_path / "other.py"
-    other.write_text("__version__ = '1.0.0'", encoding="utf-8")
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    init = pkg / "__init__.py"
+    init.write_text("__version__ = '1.0.0'", encoding="utf-8")
 
-    apply_bump(
-        "minor",
-        py,
-        paths=[str(py), str(other)],
-        ignore=[str(other)],
-    )
-    assert "__version__ = '1.0.0'" in other.read_text(encoding="utf-8")
+    apply_bump("minor", py, ignore=[str(init)])
+    assert "__version__ = '1.0.0'" in init.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- load version file paths from configuration when bumping
- search setup.py and package __init__ modules for __version__ by default
- document configurable version file paths

## Testing
- `ruff check .`
- `black bumpwright/config.py bumpwright/versioning.py tests/test_versioning.py`
- `isort --check-only bumpwright/config.py bumpwright/versioning.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4c0f43288322bd9bd0607cf49ddf