### PR TITLE
docs(changelog): clarify changelog usage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,13 +8,12 @@ notes go and how they are emitted.
 Using ``--changelog``
 ---------------------
 
-``--changelog FILE``
+``--changelog [FILE]``
     Append release notes for the new version to ``FILE``.
+    When ``FILE`` is omitted or set to ``-``, the changelog entry is printed to
+    standard output.
 
-``--changelog``
-    Print the changelog entry to standard output instead of updating a file.
-
-If omitted, no changelog entry is produced.
+If the option is omitted, no changelog entry is produced.
 
 Format
 ------
@@ -43,4 +42,4 @@ Projects can set a default changelog path in ``bumpwright.toml`` so the
 
 With this configuration, running ``bumpwright bump`` automatically appends the
 release notes to ``CHANGELOG.md``. To print to stdout instead, invoke
-``bumpwright bump --changelog``.
+``bumpwright bump --changelog`` (or pass ``--changelog -`` for clarity).

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,7 +27,7 @@ Example configuration showing all available sections and their default values:
    paths = ["migrations"]
 
    [changelog]
-   path = "CHANGELOG.md"
+   path = ""
 
    [version]
    paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]
@@ -163,7 +163,7 @@ Changelog
      - str
      - ``""``
      - Default file appended when running ``bumpwright bump`` with
-       ``--changelog`` omitted.
+       ``--changelog`` omitted. Empty string means no default file.
 
 All sections and keys are optional; unspecified values fall back to the
 defaults shown above.


### PR DESCRIPTION
## Summary
- document that `--changelog` prints to stdout when no file or `-` is provided
- correct default `changelog.path` configuration example and explain empty value means no default file

## Testing
- `isort .`
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4f1038488322987d2af38508dfaf