### PR TITLE
feat(cli): add repository URL for markdown commit links

### DIFF
--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -380,7 +380,13 @@ def bump_command(args: argparse.Namespace) -> int:
         base = last_release_commit() or f"{args.head}^"
         commits = collect_commits(base, args.head)
         lines = [f"## [v{vc.new}] - {date.today().isoformat()}"]
-        lines.extend(f"- {sha} {subject}" for sha, subject in commits)
+        for sha, subject in commits:
+            if args.repo_url and args.format == "md":
+                base_url = args.repo_url.rstrip("/")
+                link = f"{base_url}/commit/{sha}"
+                lines.append(f"- [{sha}]({link}) {subject}")
+            else:
+                lines.append(f"- {sha} {subject}")
         changelog = "\n".join(lines) + "\n"
     if args.format == "json":
         print(
@@ -465,6 +471,10 @@ def main(argv: list[str] | None = None) -> int:
         default="text",
         help="Output style: plain text, Markdown, or machine-readable JSON.",
     )
+    p_decide.add_argument(
+        "--repo-url",
+        help="Base repository URL for linking commit hashes in Markdown output.",
+    )
     p_decide.set_defaults(func=decide_command)
 
     p_bump = sub.add_parser(
@@ -494,6 +504,10 @@ def main(argv: list[str] | None = None) -> int:
         choices=["text", "md", "json"],
         default="text",
         help="Output style: plain text, Markdown, or machine-readable JSON.",
+    )
+    p_bump.add_argument(
+        "--repo-url",
+        help="Base repository URL for linking commit hashes in Markdown output.",
     )
     p_bump.add_argument(
         "--pyproject",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,6 +47,9 @@ Compare two git references and report the semantic version level they require.
     Output style. ``text`` prints plain console output, ``md`` emits Markdown,
     and ``json`` produces machine-readable data. Defaults to ``text``.
 
+``--repo-url URL``
+    Base repository URL for linking commit hashes in Markdown output.
+
 **Examples**
 
 .. code-block:: console
@@ -112,6 +115,9 @@ files for a ``__version__`` variable. These locations can be customised via the
     Output style. ``text`` prints plain console output, ``md`` emits Markdown,
     and ``json`` produces machine-readable data. Defaults to ``text``.
 
+``--repo-url URL``
+    Base repository URL for linking commit hashes in Markdown output.
+
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to
     ``pyproject.toml``.
@@ -159,6 +165,17 @@ This prints the old and new versions and, when ``--commit`` and ``--tag`` are
 set, commits and tags the release. Omitting ``--base`` compares against the
 last release commit or the previous commit (``HEAD^``), and omitting
 ``--head`` assumes ``HEAD``.
+
+Generate a Markdown changelog with commit links:
+
+.. code-block:: console
+
+   bumpwright bump --dry-run --format md --repo-url https://github.com/me/project --changelog -
+
+.. code-block:: text
+
+   ## [v1.2.4] - 2024-04-01
+   - [abc123](https://github.com/me/project/commit/abc123) feat: change
 
 To preview changes without touching the filesystem, combine ``--dry-run`` with
 JSON output:

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -40,3 +40,41 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
     today = date.today().isoformat()
     assert f"## [v0.1.1] - {today}" in content
     assert f"- {sha} feat: change" in content
+
+
+def test_changelog_links_repo_url(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(["git", "commit", "-am", "feat: change"], repo)
+    sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+            "--changelog",
+            "CHANGELOG.md",
+            "--format",
+            "md",
+            "--repo-url",
+            "https://example.com/repo",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    content = (repo / "CHANGELOG.md").read_text()
+    expected = f"- [{sha}](https://example.com/repo/commit/{sha}) feat: change"
+    assert expected in content


### PR DESCRIPTION
## Summary
- support `--repo-url` option so markdown outputs can link commit hashes
- document the repository URL option with usage examples

## Testing
- `ruff check bumpwright/cli.py tests/test_cli_changelog.py`
- `black bumpwright/cli.py tests/test_cli_changelog.py`
- `isort --check-only --profile black -v bumpwright/cli.py tests/test_cli_changelog.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4f138a4883228457532a5a7b6437