### PR TITLE
feat(cli): merge decision logic into bump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ pip install bumpwright
 ```
 
 ## Quick start
-| Subcommand | Purpose | Key options |
-|------------|---------|-------------|
-| `decide`   | Recommend a bump between two references | `--base`, `--head`, `--format` |
-| `bump`     | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
+| Command | Purpose | Key options |
+|---------|---------|-------------|
+| `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format` |
+| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
 
 1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:
 
@@ -50,14 +50,14 @@ pip install bumpwright
 2. **Suggest the next version** between two git references:
 
    ```console
-   $ bumpwright decide --base origin/main --head HEAD --format text
+   $ bumpwright bump --decide --base origin/main --head HEAD --format text
    bumpwright suggests: minor
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```
 
    ```console
-   $ bumpwright decide --base origin/main --head HEAD --format md
+   $ bumpwright bump --decide --base origin/main --head HEAD --format md
    **bumpwright** suggests: `minor`
 
 
@@ -65,7 +65,7 @@ pip install bumpwright
    ```
 
    ```console
-   $ bumpwright decide --base origin/main --head HEAD --format json
+   $ bumpwright bump --decide --base origin/main --head HEAD --format json
    {"level": "minor", "changes": [{"severity": "minor", "symbol": "cli.new_command", "description": "added CLI entry 'greet'"}]}
    ```
 
@@ -80,7 +80,7 @@ pip install bumpwright
    ```
 
    Omitting ``--level`` triggers an automatic decision using ``--base`` and
-   ``--head`` in the same manner as the ``decide`` command.
+   ``--head``.
 
 4. **Run everything in one step** with automatic bumping and tagging:
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -47,7 +47,7 @@ Integrating with CI pipelines
               with:
                 python-version: '3.x'
             - run: pip install bumpwright
-            - run: bumpwright decide --base origin/main --head ${{ github.sha }}
+            - run: bumpwright bump --decide --base origin/main --head ${{ github.sha }}
 
 2. Review the workflow logs to see the suggested bump:
 
@@ -119,7 +119,7 @@ Custom severity mapping and plugin analysers
 
    .. code-block:: console
 
-      bumpwright decide --base HEAD^ --head HEAD
+      bumpwright bump --decide --base HEAD^ --head HEAD
 
    .. code-block:: text
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,11 +1,11 @@
 Usage
 =====
 
-The ``bumpwright`` command-line interface provides three subcommands to help
+The ``bumpwright`` command-line interface provides two subcommands to help
 manage project versions based on public API changes. By default, the
-``decide`` and ``bump`` subcommands compare the current commit against the last
-release commit, or the previous commit (``HEAD^``) when no release exists. This
-section explains each command, its arguments, and expected outputs.
+``bump`` subcommand compares the current commit against the last release
+commit, or the previous commit (``HEAD^``) when no release exists. This section
+explains each command, its arguments, and expected outputs.
 
 Global options
 --------------
@@ -28,10 +28,12 @@ release commits.
 
    bumpwright init
 
-``decide`` – suggest a bump
----------------------------
 
-Compare two git references and report the semantic version level they require.
+``bump --decide`` – suggest a bump
+----------------------------------
+
+Compare two git references and report the semantic version level they
+require.
 
 **Arguments**
 
@@ -55,7 +57,7 @@ Compare two git references and report the semantic version level they require.
 .. code-block:: console
 
    # Omitting --head defaults to the current HEAD
-   bumpwright decide --base origin/main --format json
+   bumpwright bump --decide --base origin/main --format json
 
 .. code-block:: json
 
@@ -66,13 +68,13 @@ Compare two git references and report the semantic version level they require.
      ]
    }
 
-Running ``bumpwright decide`` without ``--base`` compares the current commit
-against the last release commit or, if none exists, its parent (``HEAD^``).
-Because this subcommand only inspects commits, there is no ``--dry-run`` flag.
+Running ``bumpwright bump --decide`` without ``--base`` compares the current
+commit against the last release commit or, if none exists, its parent (``HEAD^``).
+Because this mode only inspects commits, there is no effect on the filesystem.
 
 .. code-block:: console
 
-   bumpwright decide --format json
+   bumpwright bump --decide --format json
 
 .. code-block:: json
 
@@ -87,7 +89,7 @@ Omitting ``--head`` uses the current ``HEAD``:
 
 .. code-block:: console
 
-   bumpwright decide --base origin/main --format json
+   bumpwright bump --decide --base origin/main --format json
 
 ``bump`` – apply a bump
 -----------------------

--- a/tests/test_cli_bump_decide_parity.py
+++ b/tests/test_cli_bump_decide_parity.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from tests.cli_helpers import run, setup_repo
 
 
-def test_bump_and_decide_agree_on_no_api_changes(tmp_path: Path) -> None:
-    """bump and decide should both detect no bump when API is unchanged."""
+def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
+    """``bump --decide`` should detect no bump when the API is unchanged."""
     repo, pkg, _ = setup_repo(tmp_path)
 
     # Modify implementation without changing the public API.
@@ -21,7 +21,7 @@ def test_bump_and_decide_agree_on_no_api_changes(tmp_path: Path) -> None:
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
 
     res_decide = subprocess.run(
-        [sys.executable, "-m", "bumpwright.cli", "decide"],
+        [sys.executable, "-m", "bumpwright.cli", "bump", "--decide"],
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,

--- a/tests/test_cli_decide_default.py
+++ b/tests/test_cli_decide_default.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tests.cli_helpers import run, setup_repo
 
 
-def test_decide_defaults_to_previous_commit(tmp_path: Path) -> None:
+def test_decide_flag_defaults_to_previous_commit(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
 
     (pkg / "extra.py").write_text("def bar() -> int:\n    return 2\n", encoding="utf-8")
@@ -19,7 +19,8 @@ def test_decide_defaults_to_previous_commit(tmp_path: Path) -> None:
             sys.executable,
             "-m",
             "bumpwright.cli",
-            "decide",
+            "bump",
+            "--decide",
             "--format",
             "json",
         ],


### PR DESCRIPTION
## Summary
- consolidate version suggestions into `bump --decide`
- drop standalone `decide` command and align tests
- document `--decide` usage across README and docs

## Testing
- `ruff check .`
- `isort README.md bumpwright/cli.py docs/advanced.rst docs/usage.rst tests/test_cli_bump_decide_parity.py tests/test_cli_decide_default.py`
- `black bumpwright/cli.py tests/test_cli_bump_decide_parity.py tests/test_cli_decide_default.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f67254cd8832288dbb122a3ac5d7e