### PR TITLE
feat(versioning): expand default version file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Design goals include:
 - Output in plain text, Markdown or JSON for easy integration.
 - Optional helpers to update version numbers across common files and tag the release.
 
+The bump command updates version strings in ``pyproject.toml``, ``setup.py``,
+``setup.cfg`` and any ``__init__.py``, ``version.py`` or ``_version.py`` files
+by default. Use ``--version-ignore`` or configuration settings to exclude
+locations.
+
 ## Installation
 
 ```bash

--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -301,7 +301,9 @@ def bump_command(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    paths = args.version_path or cfg.version.paths
+    paths = list(cfg.version.paths)
+    if args.version_path:
+        paths.extend(args.version_path)
     version_files = {p for p in paths if not any(ch in p for ch in "*?[")}
 
     try:
@@ -329,7 +331,9 @@ def bump_command(args: argparse.Namespace) -> int:
             print("No version bump needed")
             return 0
 
-    ignore = args.version_ignore or cfg.version.ignore
+    ignore = list(cfg.version.ignore)
+    if args.version_ignore:
+        ignore.extend(args.version_ignore)
     vc = apply_bump(
         level,
         pyproject_path=pyproject,
@@ -357,14 +361,17 @@ def bump_command(args: argparse.Namespace) -> int:
                     "old_version": vc.old,
                     "new_version": vc.new,
                     "level": vc.level,
+                    "files": [str(p) for p in vc.files],
                 },
                 indent=2,
             )
         )
     elif args.format == "md":
         print(f"Bumped version: `{vc.old}` -> `{vc.new}` ({vc.level})")
+        print("Updated files:\n" + "\n".join(f"- `{p}`" for p in vc.files))
     else:
         print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
+        print("Updated files: " + ", ".join(str(p) for p in vc.files))
     if not args.dry_run:
         _commit_tag(str(pyproject), vc.new, args.commit, args.tag)
     if changelog is not None:
@@ -456,13 +463,19 @@ def main(argv: list[str] | None = None) -> int:
         "--version-path",
         action="append",
         dest="version_path",
-        help="Glob pattern for files that contain the project version (repeatable).",
+        help=(
+            "Additional glob pattern for files containing the project version "
+            "(repeatable). Defaults include pyproject.toml, setup.py, setup.cfg, "
+            "and any __init__.py, version.py, or _version.py files."
+        ),
     )
     p_bump.add_argument(
         "--version-ignore",
         action="append",
         dest="version_ignore",
-        help="Glob pattern for paths to exclude from version updates.",
+        help=(
+            "Glob pattern for paths to exclude from version updates " "(repeatable)."
+        ),
     )
     p_bump.add_argument(
         "--commit",

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -17,7 +17,14 @@ _DEFAULTS = {
     "analyzers": {"cli": False},
     "migrations": {"paths": ["migrations"]},
     "version": {
-        "paths": ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py"],
+        "paths": [
+            "pyproject.toml",
+            "setup.py",
+            "setup.cfg",
+            "**/__init__.py",
+            "**/version.py",
+            "**/_version.py",
+        ],
         "ignore": [],
     },
 }
@@ -81,6 +88,8 @@ class VersionFiles:
             "setup.py",
             "setup.cfg",
             "**/__init__.py",
+            "**/version.py",
+            "**/_version.py",
         ]
     )
     ignore: List[str] = field(default_factory=list)

--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from glob import glob
 from pathlib import Path
@@ -27,11 +27,13 @@ class VersionChange:
         old: Previous version string.
         new: New version string after bump.
         level: Bump level applied (``"major"``, ``"minor"``, or ``"patch"``).
+        files: Files updated with the new version.
     """
 
     old: str
     new: str
     level: str  # "major" | "minor" | "patch"
+    files: List[Path] = field(default_factory=list)
 
 
 def bump_string(v: str, level: str) -> str:
@@ -146,15 +148,17 @@ def apply_bump(
         pyproject_path: Path to the canonical ``pyproject.toml`` file.
         dry_run: If ``True``, compute the new version without writing to disk.
         paths: Glob patterns pointing to files that may contain the version.
-            If ``None``, patterns are loaded from ``config_path``.
-            The canonical ``pyproject.toml`` is always updated.
+            Defaults include ``pyproject.toml``, ``setup.py``, ``setup.cfg`` and
+            any ``__init__.py``, ``version.py`` or ``_version.py`` files within
+            the project. Custom patterns extend this list.
         ignore: Glob patterns to exclude from ``paths``. Defaults to values from
             ``config_path`` when ``None``.
         config_path: Path to a ``bumpwright`` configuration file defining
             default version locations.
 
     Returns:
-        :class:`VersionChange` detailing the old and new versions.
+        :class:`VersionChange` detailing the old and new versions and updated
+        files.
     """
 
     cfg = None
@@ -171,8 +175,13 @@ def apply_bump(
         return VersionChange(old=old, new=new, level=level)
 
     write_project_version(new, pyproject_path)
-    _update_additional_files(new, old, paths, ignore, pyproject_path)
-    return VersionChange(old=old, new=new, level=level)
+    updated = _update_additional_files(new, old, paths, ignore, pyproject_path)
+    return VersionChange(
+        old=old,
+        new=new,
+        level=level,
+        files=[Path(pyproject_path), *updated],
+    )
 
 
 def _update_additional_files(
@@ -181,7 +190,7 @@ def _update_additional_files(
     patterns: Iterable[str],
     ignore: Iterable[str],
     pyproject_path: str | Path,
-) -> None:
+) -> List[Path]:
     """Update version strings in files matching ``patterns``.
 
     Args:
@@ -190,15 +199,21 @@ def _update_additional_files(
         patterns: Glob patterns to search for files.
         ignore: Glob patterns to skip.
         pyproject_path: Canonical ``pyproject.toml`` path to skip (already updated).
+
+    Returns:
+        List of files that were updated.
     """
 
     base = Path(pyproject_path).resolve().parent
     files = _resolve_files(patterns, ignore, base)
     canon = Path(pyproject_path).resolve()
+    changed: List[Path] = []
     for f in files:
         if f.resolve() == canon:
             continue
         _replace_version(f, old, new)
+        changed.append(f)
+    return changed
 
 
 def _resolve_files(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,12 +142,15 @@ Controls where version strings are read and updated.
      - Description
    * - ``paths``
      - list[str]
-     - ``["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]``
+     - ``["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]``
      - Glob patterns scanned for version declarations.
    * - ``ignore``
      - list[str]
      - ``[]``
      - Glob patterns excluded from version replacement.
+
+Command-line options ``--version-path`` and ``--version-ignore`` extend these
+defaults for one-off runs.
 
 Changelog
 ~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -95,10 +95,11 @@ Omitting ``--head`` uses the current ``HEAD``:
 -----------------------
 
 Update version information in ``pyproject.toml`` and other files.
-By default, ``bumpwright`` also searches ``setup.py`` and any ``__init__.py``
-files for a ``__version__`` variable. These locations can be customised via the
-``[version]`` section in ``bumpwright.toml`` or overridden with
-``--version-path``/``--version-ignore``.
+By default, ``bumpwright`` also searches ``setup.py``, ``setup.cfg`` and any
+``__init__.py``, ``version.py`` or ``_version.py`` files for a version
+assignment. These locations can be customised via the ``[version]`` section in
+``bumpwright.toml`` or augmented with ``--version-path`` and
+``--version-ignore`` to add or exclude patterns.
 
 **Arguments**
 


### PR DESCRIPTION
## Summary
- expand default version file search to include setup.cfg and common version modules
- surface updated files when bumping and allow extending or ignoring defaults via CLI
- document default version file behavior and customization options

## Testing
- `poetry run isort .`
- `poetry run black .`
- `poetry run ruff check . --fix`
- `poetry run pytest`

## Label
- feat

------
https://chatgpt.com/codex/tasks/task_e_68a03e847e4483229f57a74e6d48e216