### PR TITLE
docs(core): improve docstrings and type hints

### DIFF
--- a/bumpwright/analyzers/__init__.py
+++ b/bumpwright/analyzers/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Protocol, Type
+from typing import Callable, Dict, List, Protocol, Type
 
 from ..compare import Impact
 from ..config import Config
@@ -45,7 +45,9 @@ class AnalyzerInfo:
 REGISTRY: Dict[str, AnalyzerInfo] = {}
 
 
-def register(name: str, description: str | None = None):
+def register(
+    name: str, description: str | None = None
+) -> Callable[[Type[Analyzer]], Type[Analyzer]]:
     """Decorator registering an analyzer implementation.
 
     Args:

--- a/bumpwright/analyzers/cli.py
+++ b/bumpwright/analyzers/cli.py
@@ -21,12 +21,28 @@ class Command:
 
 
 def _is_str(node: ast.AST) -> bool:
-    """Return ``True`` if ``node`` is a constant string."""
+    """Return whether ``node`` is a constant string.
+
+    Args:
+        node: AST node to examine.
+
+    Returns:
+        ``True`` if the node represents a string literal.
+    """
+
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
 def _extract_click(node: ast.FunctionDef) -> Command | None:
-    """Extract click command metadata from a function definition."""
+    """Extract click command metadata from a function definition.
+
+    Args:
+        node: Function definition node.
+
+    Returns:
+        :class:`Command` description if ``node`` defines a click command, otherwise
+        ``None``.
+    """
 
     cmd_name: str | None = None
     options: Dict[str, bool] = {}
@@ -80,7 +96,15 @@ def _extract_click(node: ast.FunctionDef) -> Command | None:
 
 
 def _extract_argparse(tree: ast.AST) -> Dict[str, Command]:
-    """Extract argparse commands from AST."""
+    """Extract argparse commands from AST.
+
+    Args:
+        tree: Parsed module AST.
+
+    Returns:
+        Mapping of command name to :class:`Command` objects discovered via
+        ``argparse``.
+    """
 
     commands: Dict[str, Command] = {}
     parsers: Dict[str, str] = {}
@@ -133,7 +157,14 @@ def _extract_argparse(tree: ast.AST) -> Dict[str, Command]:
 
 
 def extract_cli_from_source(code: str) -> Dict[str, Command]:
-    """Extract command definitions from source code."""
+    """Extract command definitions from source code.
+
+    Args:
+        code: Python source text to analyze.
+
+    Returns:
+        Mapping of command name to :class:`Command` definitions.
+    """
 
     tree = ast.parse(code)
     commands: Dict[str, Command] = {}
@@ -147,7 +178,15 @@ def extract_cli_from_source(code: str) -> Dict[str, Command]:
 
 
 def diff_cli(old: Dict[str, Command], new: Dict[str, Command]) -> List[Impact]:
-    """Compare CLI definitions and compute impacts."""
+    """Compare CLI definitions and compute impacts.
+
+    Args:
+        old: Command mapping for the base reference.
+        new: Command mapping for the head reference.
+
+    Returns:
+        List of detected impacts between the two mappings.
+    """
 
     impacts: List[Impact] = []
     for name in old.keys() - new.keys():
@@ -176,7 +215,16 @@ def diff_cli(old: Dict[str, Command], new: Dict[str, Command]) -> List[Impact]:
 def _build_cli_at_ref(
     ref: str, roots: Iterable[str], ignores: Iterable[str]
 ) -> Dict[str, Command]:
-    """Collect commands for all modules at a git ref."""
+    """Collect commands for all modules at a git ref.
+
+    Args:
+        ref: Git reference to inspect.
+        roots: Root directories to scan.
+        ignores: Glob patterns to exclude.
+
+    Returns:
+        Mapping of command name to :class:`Command` objects present at ``ref``.
+    """
 
     out: Dict[str, Command] = {}
     for path in list_py_files_at_ref(ref, roots, ignore_globs=ignores):
@@ -196,11 +244,28 @@ class CLIAnalyzer:
         self.cfg = cfg
 
     def collect(self, ref: str) -> Dict[str, Command]:
-        """Collect CLI commands at the given ref."""
+        """Collect CLI commands at the given ref.
+
+        Args:
+            ref: Git reference to inspect.
+
+        Returns:
+            Mapping of command name to :class:`Command` objects.
+        """
+
         return _build_cli_at_ref(
             ref, self.cfg.project.public_roots, self.cfg.ignore.paths
         )
 
     def compare(self, old: Dict[str, Command], new: Dict[str, Command]) -> List[Impact]:
-        """Compare two command mappings and return impacts."""
+        """Compare two command mappings and return impacts.
+
+        Args:
+            old: Baseline command mapping.
+            new: Updated command mapping.
+
+        Returns:
+            List of impacts describing CLI changes.
+        """
+
         return diff_cli(old, new)

--- a/bumpwright/analyzers/migrations.py
+++ b/bumpwright/analyzers/migrations.py
@@ -20,6 +20,12 @@ class _UpgradeVisitor(ast.NodeVisitor):
     """AST visitor that records schema-changing operations."""
 
     def __init__(self, path: str) -> None:
+        """Create a visitor for a specific migration file.
+
+        Args:
+            path: Path to the migration being inspected.
+        """
+
         self.path = path
         self.impacts: List[Impact] = []
 
@@ -43,7 +49,16 @@ class _UpgradeVisitor(ast.NodeVisitor):
 
 
 def _analyze_add_column(node: ast.Call, path: str) -> Optional[Impact]:
-    """Determine the impact of an ``op.add_column`` call."""
+    """Determine the impact of an ``op.add_column`` call.
+
+    Args:
+        node: AST call node representing ``op.add_column``.
+        path: Path of the migration file being analyzed.
+
+    Returns:
+        Impact describing the column addition, or ``None`` if the operation
+        cannot be assessed.
+    """
 
     column = None
     for arg in node.args:
@@ -68,7 +83,15 @@ def _analyze_add_column(node: ast.Call, path: str) -> Optional[Impact]:
 
 
 def _analyze_content(path: str, content: str) -> List[Impact]:
-    """Parse migration source and collect impacts."""
+    """Parse migration source and collect impacts.
+
+    Args:
+        path: Path of the migration file.
+        content: Source code of the migration.
+
+    Returns:
+        List of detected impacts within the migration.
+    """
 
     try:
         tree = ast.parse(content)

--- a/bumpwright/analyzers/web_routes.py
+++ b/bumpwright/analyzers/web_routes.py
@@ -30,7 +30,15 @@ class Route:
 
 
 def _is_const_str(node: ast.AST) -> bool:
-    """Return ``True`` if ``node`` is a constant string."""
+    """Return whether ``node`` is a constant string.
+
+    Args:
+        node: AST node to inspect.
+
+    Returns:
+        ``True`` if ``node`` represents a string literal.
+    """
+
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
@@ -100,7 +108,16 @@ def extract_routes_from_source(code: str) -> Dict[Tuple[str, str], Route]:
 def _build_routes_at_ref(
     ref: str, roots: Iterable[str], ignores: Iterable[str]
 ) -> Dict[Tuple[str, str], Route]:
-    """Collect routes for all modules under given roots at a git ref."""
+    """Collect routes for all modules under given roots at a git ref.
+
+    Args:
+        ref: Git reference to inspect.
+        roots: Root directories to search for Python modules.
+        ignores: Glob patterns to exclude from scanning.
+
+    Returns:
+        Mapping of ``(path, method)`` to :class:`Route` objects present at ``ref``.
+    """
 
     out: Dict[Tuple[str, str], Route] = {}
     for path in list_py_files_at_ref(ref, roots, ignore_globs=ignores):
@@ -114,7 +131,15 @@ def _build_routes_at_ref(
 def diff_routes(
     old: Dict[Tuple[str, str], Route], new: Dict[Tuple[str, str], Route]
 ) -> List[Impact]:
-    """Compute impacts between two route mappings."""
+    """Compute impacts between two route mappings.
+
+    Args:
+        old: Mapping of routes for the base reference.
+        new: Mapping of routes for the head reference.
+
+    Returns:
+        List of detected route impacts.
+    """
 
     impacts: List[Impact] = []
 
@@ -158,7 +183,15 @@ class WebRoutesAnalyzer:
         self.cfg = cfg
 
     def collect(self, ref: str) -> Dict[Tuple[str, str], Route]:
-        """Collect route definitions at ``ref``."""
+        """Collect route definitions at ``ref``.
+
+        Args:
+            ref: Git reference to inspect.
+
+        Returns:
+            Mapping of ``(path, method)`` to :class:`Route` objects.
+        """
+
         return _build_routes_at_ref(
             ref, self.cfg.project.public_roots, self.cfg.ignore.paths
         )
@@ -166,5 +199,14 @@ class WebRoutesAnalyzer:
     def compare(
         self, old: Dict[Tuple[str, str], Route], new: Dict[Tuple[str, str], Route]
     ) -> List[Impact]:
-        """Compare two route mappings and return impacts."""
+        """Compare two route mappings and return impacts.
+
+        Args:
+            old: Baseline route mapping.
+            new: Updated route mapping.
+
+        Returns:
+            List of impacts describing route changes.
+        """
+
         return diff_routes(old, new)

--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -221,7 +221,15 @@ def init_command(_args: argparse.Namespace) -> int:
 
 
 def _decide_only(args: argparse.Namespace, cfg: Config) -> int:
-    """Handle ``bump --decide`` mode."""
+    """Handle ``bump --decide`` mode.
+
+    Args:
+        args: Parsed command-line arguments.
+        cfg: Project configuration settings.
+
+    Returns:
+        Process exit code.
+    """
 
     base = args.base or last_release_commit() or "HEAD^"
     head = args.head
@@ -249,7 +257,15 @@ def _decide_only(args: argparse.Namespace, cfg: Config) -> int:
 
 
 def _resolve_refs(args: argparse.Namespace, level: str | None) -> tuple[str, str]:
-    """Determine base and head git references."""
+    """Determine base and head git references.
+
+    Args:
+        args: Parsed command-line arguments.
+        level: Desired bump level if already known.
+
+    Returns:
+        Tuple of ``(base, head)`` references.
+    """
 
     if args.base:
         base = args.base
@@ -261,7 +277,15 @@ def _resolve_refs(args: argparse.Namespace, level: str | None) -> tuple[str, str
 
 
 def _safe_changed_paths(base: str, head: str) -> set[str] | None:
-    """Return changed paths, handling missing history gracefully."""
+    """Return changed paths, handling missing history gracefully.
+
+    Args:
+        base: Older git reference.
+        head: Newer git reference.
+
+    Returns:
+        Set of changed file paths or ``None`` if history lookup fails.
+    """
 
     try:
         return changed_paths(base, head)
@@ -270,7 +294,16 @@ def _safe_changed_paths(base: str, head: str) -> set[str] | None:
 
 
 def _infer_level(base: str, head: str, cfg: Config) -> str | None:
-    """Compute bump level from repository differences."""
+    """Compute bump level from repository differences.
+
+    Args:
+        base: Base git reference.
+        head: Head git reference.
+        cfg: Project configuration settings.
+
+    Returns:
+        Suggested bump level or ``None`` if no change is required.
+    """
 
     old_api = _build_api_at_ref(base, cfg.project.public_roots, cfg.ignore.paths)
     new_api = _build_api_at_ref(head, cfg.project.public_roots, cfg.ignore.paths)
@@ -282,7 +315,15 @@ def _infer_level(base: str, head: str, cfg: Config) -> str | None:
 
 
 def _build_changelog(args: argparse.Namespace, new_version: str) -> str | None:
-    """Generate changelog text if requested."""
+    """Generate changelog text if requested.
+
+    Args:
+        args: Parsed command-line arguments.
+        new_version: Newly computed project version.
+
+    Returns:
+        Rendered changelog text or ``None`` when changelog generation is disabled.
+    """
 
     if args.changelog is None:
         return None
@@ -300,7 +341,14 @@ def _build_changelog(args: argparse.Namespace, new_version: str) -> str | None:
 
 
 def bump_command(args: argparse.Namespace) -> int:
-    """Apply a version bump based on repository changes."""
+    """Apply a version bump based on repository changes.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Returns:
+        Process exit code.
+    """
 
     cfg = load_config(args.config)
     if args.decide:

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -115,8 +115,16 @@ class Config:
     version: VersionFiles = field(default_factory=VersionFiles)
 
 
-def _merge_defaults(data: dict) -> dict:
-    """Merge user data with default configuration."""
+def _merge_defaults(data: dict | None) -> dict:
+    """Merge user configuration with built-in defaults.
+
+    Args:
+        data: Raw configuration mapping or ``None`` for no user overrides.
+
+    Returns:
+        Combined configuration with defaults applied.
+    """
+
     out = {k: dict(v) for k, v in _DEFAULTS.items()}
     for section, content in (data or {}).items():
         out.setdefault(section, {}).update(content or {})

--- a/bumpwright/public_api.py
+++ b/bumpwright/public_api.py
@@ -56,13 +56,27 @@ PublicAPI = Dict[str, FuncSig]  # symbol -> function signature (functions & meth
 
 
 def _render_expr(node: ast.AST | None) -> str | None:
-    """Render arbitrary expressions (defaults, etc.)."""
+    """Render arbitrary expressions such as default values.
+
+    Args:
+        node: AST node to render.
+
+    Returns:
+        String representation of ``node`` or ``None`` if ``node`` is ``None``.
+    """
 
     return ast.unparse(node) if node is not None else None
 
 
 def _render_type(ann: ast.AST | None) -> str | None:
-    """Safely render type annotations (params & returns)."""
+    """Safely render type annotations for parameters and returns.
+
+    Args:
+        ann: Annotation node to render.
+
+    Returns:
+        String form of the annotation or ``None`` if absent.
+    """
 
     return ast.unparse(ann) if ann is not None else None
 
@@ -93,7 +107,14 @@ def _parse_exports(mod: ast.Module) -> Optional[set[str]]:
 
 
 def _param_list(args: ast.arguments) -> List[Param]:
-    """Convert AST parameters to :class:`Param` instances."""
+    """Convert AST parameters to :class:`Param` instances.
+
+    Args:
+        args: Function arguments node from the AST.
+
+    Returns:
+        Ordered list of parameter descriptors.
+    """
 
     out: List[Param] = []
 
@@ -132,7 +153,14 @@ def _param_list(args: ast.arguments) -> List[Param]:
 
 
 def _is_public(name: str) -> bool:
-    """Return ``True`` if ``name`` represents a public symbol."""
+    """Return whether ``name`` represents a public symbol.
+
+    Args:
+        name: Symbol name to evaluate.
+
+    Returns:
+        ``True`` if ``name`` does not begin with an underscore.
+    """
 
     return not name.startswith("_")
 
@@ -143,12 +171,13 @@ def _is_public(name: str) -> bool:
 class _APIVisitor(ast.NodeVisitor):
     """Collect public function and method signatures from a module."""
 
-    def __init__(self, module_name: str, exports: Optional[set[str]]):
+    def __init__(self, module_name: str, exports: set[str] | None) -> None:
         """Initialize the visitor.
 
         Args:
             module_name: Name of the module being inspected.
             exports: Explicitly exported symbols if ``__all__`` is defined.
+                ``None`` indicates that all public symbols are considered.
         """
 
         self.module_name = module_name

--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -146,7 +146,7 @@ def apply_bump(
         level: Bump level to apply (``"major"``, ``"minor"``, or ``"patch"``).
             pyproject_path: Path to the canonical ``pyproject.toml`` file.
         dry_run: If ``True``, compute the new version without writing to disk.
-        paths: Glob patterns pointing to files that may contain the version. 
+        paths: Glob patterns pointing to files that may contain the version.
             Defaults include ``pyproject.toml``, ``setup.py``, ``setup.cfg`` and
             any ``__init__.py``, ``version.py`` or ``_version.py`` files within
             the project. Custom patterns extend this list.
@@ -218,7 +218,16 @@ def _update_additional_files(
 def _resolve_files(
     patterns: Iterable[str], ignore: Iterable[str], base_dir: Path
 ) -> List[Path]:
-    """Expand glob patterns while applying ignore rules relative to ``base_dir``."""
+    """Expand glob patterns while applying ignore rules relative to ``base_dir``.
+
+    Args:
+        patterns: Glob patterns to search for version files.
+        ignore: Glob patterns to exclude from results.
+        base_dir: Directory relative to which patterns are evaluated.
+
+    Returns:
+        List of discovered file paths matching ``patterns`` minus ``ignore``.
+    """
 
     out: List[Path] = []
     ignore_list = list(ignore)
@@ -242,7 +251,13 @@ def _resolve_files(
 
 
 def _replace_version(path: Path, old: str, new: str) -> None:
-    """Replace occurrences of ``old`` version with ``new`` in ``path``."""
+    """Replace occurrences of ``old`` version with ``new`` in ``path``.
+
+    Args:
+        path: File whose contents should be updated.
+        old: Previous version string.
+        new: New version string.
+    """
 
     text = path.read_text(encoding="utf-8")
     patterns = [


### PR DESCRIPTION
## Summary
- expand analyzer registry decorator with explicit return typing and docs
- flesh out CLI helper docstrings and annotate return paths
- document public API extraction utilities and version helpers

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0427724c88322939aaf9d03b8c2a0