### PR TITLE
feat(compare): record minor impact for optional parameter removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ alternative with ``--config``.
 
 ### Analyzer reference
 
+#### Python API
+
+Compares Python function and method signatures to detect changes.
+
+Severity rules:
+
+- Removed public symbol → **major**
+- Added public symbol → **minor**
+- Removed required parameter → **major**
+- Removed optional parameter → **minor**
+- Added optional parameter → **minor**
+- Parameter kind changed → **major**
+- Return annotation changed → **minor**
+
 #### CLI (``cli``)
 
 Tracks command-line interfaces defined with ``argparse`` or ``click``.

--- a/bumpwright/compare.py
+++ b/bumpwright/compare.py
@@ -55,16 +55,21 @@ def compare_funcs(
     oldp = _index_params(old)
     newp = _index_params(new)
 
-    # Removed required param -> major
+    # Removed parameters
     for name, op in oldp.items():
-        if (
-            name not in newp
-            and op.kind in ("posonly", "pos", "kwonly")
-            and op.default is None
-        ):
-            impacts.append(
-                Impact("major", old.fullname, f"Removed required param '{name}'")
-            )
+        if name not in newp:
+            if op.kind in ("posonly", "pos", "kwonly") and op.default is None:
+                impacts.append(
+                    Impact("major", old.fullname, f"Removed required param '{name}'")
+                )
+            elif op.default is not None or op.kind in (
+                "kwonly",
+                "vararg",
+                "varkw",
+            ):
+                impacts.append(
+                    Impact("minor", old.fullname, f"Removed optional param '{name}'")
+                )
 
     # Param kind changes are major; added optional params are minor
     for name, np in newp.items():

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -24,6 +24,17 @@ def test_removed_required_param_is_major():
     assert any(i.severity == "major" for i in impacts)
 
 
+def test_removed_optional_param_is_minor():
+    old = _sig(
+        "m:f",
+        [_p("x"), _p("timeout", kind="kwonly", default="None")],
+        "-> int",
+    )
+    new = _sig("m:f", [_p("x")], "-> int")
+    impacts = compare_funcs(old, new)
+    assert any(i.severity == "minor" for i in impacts)
+
+
 def test_removed_symbol_is_major():
     old = {"m:f": _sig("m:f", [_p("x")], None)}
     new = {}


### PR DESCRIPTION
## Summary
- track removal of optional parameters as a minor impact
- document core API comparison severity rules
- test optional parameter removal handling

## Testing
- `ruff check . --fix`
- `isort bumpwright/compare.py tests/test_compare.py --check-only -v`
- `black bumpwright/compare.py tests/test_compare.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a050a066108322bf41a841fecdc301