### PR TITLE
refactor(public-api): simplify module path resolution

### DIFF
--- a/bumpwright/public_api.py
+++ b/bumpwright/public_api.py
@@ -229,15 +229,16 @@ def module_name_from_path(root: str, path: str) -> str:
 
     Returns:
         Dotted module path corresponding to ``path``.
+
+    Raises:
+        ValueError: If ``path`` is not located within ``root``.
     """
 
-    rp = Path(path).with_suffix("")
-    parts = list(rp.parts)
-    root_parts = list(Path(root).parts)
-    while root_parts and parts and parts[0] == root_parts[0]:
-        parts.pop(0)
-        root_parts.pop(0)
-    return ".".join(parts)
+    try:
+        rel = Path(path).with_suffix("").relative_to(Path(root))
+    except ValueError as exc:
+        raise ValueError(f"{path!r} is not relative to {root!r}") from exc
+    return ".".join(rel.parts)
 
 
 def extract_public_api_from_source(module_name: str, code: str) -> PublicAPI:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,6 @@
-from bumpwright.public_api import extract_public_api_from_source
+import pytest
+
+from bumpwright.public_api import extract_public_api_from_source, module_name_from_path
 
 
 def test_extracts_functions_and_methods():
@@ -38,3 +40,16 @@ class Hidden:
     keys = set(api.keys())
     assert "pkg.mod:Visible.ping" in keys
     assert "pkg.mod:Hidden.ping" not in keys
+
+
+def test_module_name_from_path_nested(tmp_path):
+    root = tmp_path / "pkg"
+    path = root / "a" / "b" / "mod.py"
+    assert module_name_from_path(str(root), str(path)) == "a.b.mod"
+
+
+def test_module_name_from_path_outside_root(tmp_path):
+    root = tmp_path / "pkg"
+    path = tmp_path / "other" / "mod.py"
+    with pytest.raises(ValueError):
+        module_name_from_path(str(root), str(path))


### PR DESCRIPTION
## Summary
- use `Path.with_suffix().relative_to()` to resolve module paths
- add tests for nested packages and invalid paths

## Testing
- `isort bumpwright/public_api.py tests/test_public_api.py`
- `black bumpwright/public_api.py tests/test_public_api.py`
- `ruff check bumpwright/public_api.py tests/test_public_api.py`
- `pytest`

## Labels
- refactor

------
https://chatgpt.com/codex/tasks/task_e_68a050a0c12483228c45377866e653ab