### PR TITLE
fix(compare): flag added required parameters as major

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Severity rules:
 - Added public symbol → **minor**
 - Removed required parameter → **major**
 - Removed optional parameter → **minor**
+- Added required parameter → **major**
 - Added optional parameter → **minor**
 - Parameter kind changed → **major**
 - Return annotation changed → **minor**

--- a/bumpwright/compare.py
+++ b/bumpwright/compare.py
@@ -71,7 +71,7 @@ def compare_funcs(
                     Impact("minor", old.fullname, f"Removed optional param '{name}'")
                 )
 
-    # Param kind changes are major; added optional params are minor
+    # Param kind changes are major; added params are major if required otherwise minor
     for name, np in newp.items():
         if name in oldp:
             op = oldp[name]
@@ -86,10 +86,15 @@ def compare_funcs(
                         f"Param '{name}' kind changed {op.kind}→{np.kind}",
                     )
                 )
-        elif np.default is not None or np.kind in ("kwonly", "vararg", "varkw"):
-            impacts.append(
-                Impact("minor", old.fullname, f"Added optional param '{name}'")
-            )
+        else:
+            if np.default is None and np.kind in ("posonly", "pos", "kwonly"):
+                impacts.append(
+                    Impact("major", old.fullname, f"Added required param '{name}'")
+                )
+            else:
+                impacts.append(
+                    Impact("minor", old.fullname, f"Added optional param '{name}'")
+                )
 
     # Return annotation change -> configurable severity
     if old.returns != new.returns:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -17,6 +17,13 @@ def test_added_optional_param_is_minor():
     assert any(i.severity == "minor" for i in impacts)
 
 
+def test_added_required_param_is_major():
+    old = _sig("m:f", [_p("x")], "-> int")
+    new = _sig("m:f", [_p("x"), _p("y")], "-> int")
+    impacts = compare_funcs(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
 def test_removed_required_param_is_major():
     old = _sig("m:f", [_p("x"), _p("y")], None)
     new = _sig("m:f", [_p("x")], None)


### PR DESCRIPTION
## Summary
- ensure compare_funcs reports major impact when adding required parameters
- document required parameter additions as major in Python API rules
- test added required parameter detection

## Testing
- `ruff check bumpwright tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0549525ec83229147fe1a888be15d