### PR TITLE
fix(versioning): sort resolved files deterministically

### DIFF
--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -245,6 +245,8 @@ def _resolve_files(
             if any(fnmatch(path_str, ig) or fnmatch(rel_str, ig) for ig in ignore_list):
                 continue
             out.append(p)
+    # Ensure deterministic ordering for predictable downstream operations.
+    out.sort()
     return out
 
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -49,7 +49,8 @@ def test_apply_bump_updates_extra_files(tmp_path: Path) -> None:
     assert "__version__ = '0.1.1'" in init.read_text(encoding="utf-8")
     assert "VERSION = '0.1.1'" in ver.read_text(encoding="utf-8")
     assert "version = '0.1.1'" in _ver.read_text(encoding="utf-8")
-    assert {py, setup, init, ver, _ver} <= set(out.files)
+    # Out files are sorted for deterministic order.
+    assert out.files == [py, init, _ver, ver, setup]
 
 
 def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure `_resolve_files` returns a sorted list for deterministic file ordering
- adjust versioning tests to expect sorted output

## Testing
- `isort bumpwright/versioning.py tests/test_versioning.py`
- `black bumpwright/versioning.py tests/test_versioning.py`
- `ruff check bumpwright/versioning.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a054a48510832286763eaaefeb506e