### PR TITLE
feat(changelog): support default changelog path

### DIFF
--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -351,6 +351,8 @@ def bump_command(args: argparse.Namespace) -> int:
     """
 
     cfg = load_config(args.config)
+    if args.changelog is None and cfg.changelog.path:
+        args.changelog = cfg.changelog.path
     if args.decide:
         return _decide_only(args, cfg)
 

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -16,6 +16,7 @@ _DEFAULTS = {
     "rules": {"return_type_change": "minor"},  # or "major"
     "analyzers": {"cli": False},
     "migrations": {"paths": ["migrations"]},
+    "changelog": {"path": ""},
     "version": {
         "paths": [
             "pyproject.toml",
@@ -74,6 +75,17 @@ class Migrations:
 
 
 @dataclass
+class Changelog:
+    """Changelog file configuration.
+
+    Attributes:
+        path: Default changelog file path. Empty string disables changelog generation.
+    """
+
+    path: str = ""
+
+
+@dataclass
 class VersionFiles:
     """Locations containing project version strings.
 
@@ -104,6 +116,7 @@ class Config:
         rules: Rules controlling version bumps.
         ignore: Paths to exclude when scanning.
         analyzers: Optional analyzer plugin settings.
+        changelog: Default changelog file location.
         version: Locations containing version strings.
     """
 
@@ -112,6 +125,7 @@ class Config:
     ignore: Ignore = field(default_factory=Ignore)
     analyzers: Analyzers = field(default_factory=Analyzers)
     migrations: Migrations = field(default_factory=Migrations)
+    changelog: Changelog = field(default_factory=Changelog)
     version: VersionFiles = field(default_factory=VersionFiles)
 
 
@@ -151,6 +165,7 @@ def load_config(path: str | Path = "bumpwright.toml") -> Config:
     enabled = {name for name, enabled in d["analyzers"].items() if enabled}
     analyzers = Analyzers(enabled=enabled)
     migrations = Migrations(**d.get("migrations", {}))
+    changelog = Changelog(**d.get("changelog", {}))
     version = VersionFiles(**d.get("version", {}))
     return Config(
         project=proj,
@@ -158,5 +173,6 @@ def load_config(path: str | Path = "bumpwright.toml") -> Config:
         ignore=ign,
         analyzers=analyzers,
         migrations=migrations,
+        changelog=changelog,
         version=version,
     )

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -7,6 +7,43 @@ from pathlib import Path
 from tests.cli_helpers import run, setup_repo
 
 
+def test_bump_uses_config_path(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    (repo / "bumpwright.toml").write_text(
+        "[project]\npublic_roots=['pkg']\n[changelog]\npath='CHANGELOG.md'\n",
+        encoding="utf-8",
+    )
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(["git", "commit", "-am", "feat: change"], repo)
+    sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    content = (repo / "CHANGELOG.md").read_text()
+    today = date.today().isoformat()
+    assert f"## [v0.1.1] - {today}" in content
+    assert f"- {sha} feat: change" in content
+
+
 def test_bump_writes_changelog(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,24 +1,37 @@
 import builtins
 import importlib
+from pathlib import Path
 
 import tomli
 
 from bumpwright.config import load_config
 
 
-def test_load_config_parses_analyzers(tmp_path):
+def test_load_config_parses_analyzers(tmp_path: Path) -> None:
     cfg_file = tmp_path / "bumpwright.toml"
     cfg_file.write_text("[analyzers]\nflask_routes = true\nsqlalchemy = false\n")
     cfg = load_config(cfg_file)
     assert cfg.analyzers.enabled == {"flask_routes"}
 
 
-def test_load_config_defaults_analyzers(tmp_path):
+def test_load_config_defaults_analyzers(tmp_path: Path) -> None:
     cfg = load_config(tmp_path / "missing.toml")
     assert cfg.analyzers.enabled == set()
 
 
-def test_tomli_fallback(monkeypatch, tmp_path):
+def test_load_config_changelog(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "bumpwright.toml"
+    cfg_file.write_text("[changelog]\npath='NEWS.md'\n")
+    cfg = load_config(cfg_file)
+    assert cfg.changelog.path == "NEWS.md"
+
+
+def test_load_config_changelog_default(tmp_path: Path) -> None:
+    cfg = load_config(tmp_path / "missing.toml")
+    assert cfg.changelog.path == ""
+
+
+def test_tomli_fallback(monkeypatch, tmp_path: Path) -> None:
     """Ensure ``tomli`` is used when ``tomllib`` is unavailable."""
     import bumpwright.config as config
 


### PR DESCRIPTION
## Summary
- add `changelog.path` config option with default merging
- respect `cfg.changelog.path` in `bump` when `--changelog` flag omitted
- test changelog path loading and CLI usage

## Testing
- `isort bumpwright/config.py bumpwright/cli.py tests/test_cli_changelog.py tests/test_config.py`
- `black bumpwright/config.py bumpwright/cli.py tests/test_cli_changelog.py tests/test_config.py`
- `ruff check bumpwright/config.py bumpwright/cli.py tests/test_cli_changelog.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a054d1d9bc832285919e94f7234e32