### PR TITLE
feat(cli): allow analyzer selection via CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ pip install bumpwright
 ## Quick start
 | Command | Purpose | Key options |
 |---------|---------|-------------|
-| `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format` |
-| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
+| `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format`, `--enable-analyzer`, `--disable-analyzer` |
+| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag`, `--enable-analyzer`, `--disable-analyzer` |
 
 1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:
 
@@ -51,6 +51,9 @@ pip install bumpwright
    cli = true      # enable CLI analysis
    web_routes = false  # disable route analysis
    ```
+
+   Use `--enable-analyzer` or `--disable-analyzer` on the command line to
+   override these settings for a single run.
 
 2. **Suggest the next version** between two git references:
 

--- a/bumpwright/analyzers/__init__.py
+++ b/bumpwright/analyzers/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Protocol, Type
+from typing import Callable, Dict, Iterable, List, Protocol, Type
 
 from ..compare import Impact
 from ..config import Config
@@ -67,21 +67,24 @@ def register(
     return _wrap
 
 
-def load_enabled(cfg: Config) -> List[Analyzer]:
-    """Instantiate analyzers enabled via configuration.
+def load_enabled(cfg: Config, names: Iterable[str] | None = None) -> List[Analyzer]:
+    """Instantiate analyzers enabled via configuration or overrides.
 
     Args:
         cfg: Global configuration object.
+        names: Optional explicit collection of analyzer names to load. When
+            ``None``, the names configured in ``cfg`` are used.
 
     Returns:
         List of instantiated analyzers.
 
     Raises:
-        ValueError: If a configured analyzer name is not registered.
+        ValueError: If a requested analyzer name is not registered.
     """
 
+    selected = set(cfg.analyzers.enabled if names is None else names)
     out: List[Analyzer] = []
-    for name in cfg.analyzers.enabled:
+    for name in selected:
         info = REGISTRY.get(name)
         if info is None:
             raise ValueError(f"Analyzer '{name}' is not registered")

--- a/tests/test_cli_analyzers.py
+++ b/tests/test_cli_analyzers.py
@@ -1,0 +1,170 @@
+"""Tests for enabling and disabling analyzers via CLI flags."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.cli_helpers import run, setup_repo
+
+
+def _setup_cli_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """Create a repository with CLI changes between two commits.
+
+    The first commit contains a simple CLI command. The second commit adds an
+    additional command so that the CLI analyzer would report a minor impact
+    when enabled.
+
+    Args:
+        tmp_path: Temporary directory for the repository.
+
+    Returns:
+        Tuple of ``(repo_path, base_sha, head_sha)``.
+    """
+
+    repo, pkg, _ = setup_repo(tmp_path)
+    cli_path = pkg / "cli.py"
+    cli_path.write_text(
+        """import argparse
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    p_cmd = sub.add_parser("cmd")
+    return parser
+""",
+        encoding="utf-8",
+    )
+    run(["git", "add", "pkg/cli.py"], repo)
+    run(["git", "commit", "-m", "add cli"], repo)
+    base = run(["git", "rev-parse", "HEAD"], repo)
+
+    cli_path.write_text(
+        """import argparse
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    p_cmd = sub.add_parser("cmd")
+    p_extra = sub.add_parser("extra")
+    return parser
+""",
+        encoding="utf-8",
+    )
+    run(["git", "add", "pkg/cli.py"], repo)
+    run(["git", "commit", "-m", "add extra command"], repo)
+    head = run(["git", "rev-parse", "HEAD"], repo)
+    return repo, base, head
+
+
+def test_enable_analyzer_flag(tmp_path: Path) -> None:
+    """Enabling an analyzer via CLI flag activates it for the run."""
+
+    repo, base, head = _setup_cli_repo(tmp_path)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert json.loads(res.stdout)["level"] is None
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+            "--enable-analyzer",
+            "cli",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert json.loads(res.stdout)["level"] == "minor"
+
+
+def test_disable_analyzer_flag(tmp_path: Path) -> None:
+    """Disabling an analyzer via CLI flag overrides configuration settings."""
+
+    repo, base, head = _setup_cli_repo(tmp_path)
+    (repo / "bumpwright.toml").write_text(
+        """[project]\npublic_roots=['pkg']\n[analyzers]\ncli = true\n""",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert json.loads(res.stdout)["level"] == "minor"
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+            "--disable-analyzer",
+            "cli",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert json.loads(res.stdout)["level"] is None


### PR DESCRIPTION
## Summary
- allow enabling or disabling analyzers per run via `--enable-analyzer` and `--disable-analyzer`
- support command-line overrides for analyzer configuration
- document analyzer override flags and test analyzer selection

## Testing
- `ruff check bumpwright/analyzers/__init__.py bumpwright/cli.py bumpwright/config.py tests/test_cli_analyzers.py`
- `isort bumpwright/analyzers/__init__.py bumpwright/cli.py bumpwright/config.py tests/test_cli_analyzers.py`
- `black tests/test_cli_analyzers.py bumpwright/cli.py bumpwright/analyzers/__init__.py bumpwright/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a054c1eb9483228c400ed1a00bbb7e