### PR TITLE
style(cli): adopt British 'initialise' spelling

### DIFF
--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -186,7 +186,7 @@ def _resolve_pyproject(path: str) -> Path:
 def init_command(_args: argparse.Namespace) -> int:
     """Create an empty baseline release commit.
 
-    This command records an empty ``chore(release): initialize baseline`` commit
+    This command records an empty ``chore(release): initialise baseline`` commit
     so that subsequent invocations of :func:`last_release_commit` have a
     reference point. It is typically run once when integrating bumpwright into a
     project that lacks prior release commits.
@@ -203,7 +203,7 @@ def init_command(_args: argparse.Namespace) -> int:
     """
 
     if last_release_commit() is not None:
-        print("Baseline already initialized.")
+        print("Baseline already initialised.")
         return 0
 
     subprocess.run(
@@ -212,7 +212,7 @@ def init_command(_args: argparse.Namespace) -> int:
             "commit",
             "--allow-empty",
             "-m",
-            "chore(release): initialize baseline",
+            "chore(release): initialise baseline",
         ],
         check=True,
     )
@@ -450,7 +450,7 @@ def main(argv: list[str] | None = None) -> int:
         "init",
         help="Create baseline release commit",
         description=(
-            "Create an empty 'chore(release): initialize baseline' commit to "
+            "Create an empty 'chore(release): initialise baseline' commit to "
             "establish a comparison point for future bumps."
         ),
     )

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,7 @@ Global options
 ``init`` – create a baseline
 -----------------------------
 
-Record an empty ``chore(release): initialise baseline`` commit so future runs
+Record an empty ``chore(release): initialise baseline`` commit so that future runs
 of bumpwright have a starting point for comparisons. Run this once when first
 adopting bumpwright or after importing an existing project without prior
 release commits.

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -22,6 +22,6 @@ def test_init_creates_baseline_commit(tmp_path: Path) -> None:
         env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])},
     )
     msg = run(["git", "log", "-1", "--format=%s"], repo)
-    assert msg == "chore(release): initialize baseline"
+    assert msg == "chore(release): initialise baseline"
     head = run(["git", "rev-parse", "HEAD"], repo)
     assert last_release_commit(str(repo)) == head


### PR DESCRIPTION
## Summary
- align CLI and documentation with British spelling, using `initialise`
- update init command commit message and test accordingly

## Testing
- `python -m isort --check --diff bumpwright/cli.py tests/test_cli_init.py docs/usage.rst`
- `python -m black bumpwright/cli.py tests/test_cli_init.py`
- `ruff check bumpwright/cli.py tests/test_cli_init.py`
- `pytest`

## Labels
- style

------
https://chatgpt.com/codex/tasks/task_e_68a054fc20c883229db850659883e76a