### PR TITLE
feat(cli): add analyzer override flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install bumpwright
 | Command | Purpose | Key options |
 |---------|---------|-------------|
 | `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format` |
-| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
+| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag`, `--enable-analyzer`, `--disable-analyzer` |
 
 1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:
 
@@ -148,6 +148,10 @@ aspect of bumpwright:
 - **migrations** – directories containing Alembic migration scripts.
 - **changelog** – default changelog file used with ``--changelog``.
 - **version** – files where version strings are read and updated.
+
+Use the command-line flags ``--enable-analyzer NAME`` and
+``--disable-analyzer NAME`` to temporarily override these settings for a
+single run.
 
 See ``docs/configuration.rst`` for in-depth descriptions and additional
 examples. The default file name is ``bumpwright.toml`` but you may specify an

--- a/tests/test_analyzer_flags.py
+++ b/tests/test_analyzer_flags.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from bumpwright import analyzers
+from bumpwright.analyzers import AnalyzerInfo
+from bumpwright.cli import _run_analyzers
+from bumpwright.compare import Impact
+from bumpwright.config import Config
+
+
+class DummyAnalyzer:
+    """Trivial analyzer used for flag tests."""
+
+    def __init__(self, cfg: Config) -> None:  # pragma: no cover - trivial
+        """Store configuration for later use."""
+
+        self.cfg = cfg
+
+    def collect(self, ref: str) -> str:  # pragma: no cover - trivial
+        """Return the provided reference."""
+
+        return ref
+
+    def compare(self, old: str, new: str) -> list[Impact]:  # pragma: no cover - trivial
+        """Produce a constant impact for testing."""
+
+        return [Impact("warn", "dummy", "ran")]
+
+
+def _register_dummy(monkeypatch) -> None:
+    monkeypatch.setattr(
+        analyzers,
+        "REGISTRY",
+        {"dummy": AnalyzerInfo(name="dummy", cls=DummyAnalyzer, description="")},
+    )
+
+
+def test_enable_flag_overrides_config(monkeypatch) -> None:
+    _register_dummy(monkeypatch)
+    cfg = Config()
+    impacts = _run_analyzers("base", "head", cfg, enable=["dummy"])
+    assert any(i.symbol == "dummy" for i in impacts)
+
+
+def test_disable_flag_overrides_config(monkeypatch) -> None:
+    _register_dummy(monkeypatch)
+    cfg = Config()
+    cfg.analyzers.enabled.add("dummy")
+    impacts = _run_analyzers("base", "head", cfg, disable=["dummy"])
+    assert not impacts


### PR DESCRIPTION
## Summary
- allow enabling or disabling analyzers from the CLI
- document new analyzer override flags

## Testing
- `ruff check bumpwright/cli.py tests/test_analyzer_flags.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a057348af88322b362b0a899d8dabe