### PR TITLE
feat(cli): allow enabling and disabling analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ pip install bumpwright
 ## Quick start
 | Command | Purpose | Key options |
 |---------|---------|-------------|
-| `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format` |
-| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag` |
+| `bump --decide` | Recommend a bump between two references | `--base`, `--head`, `--format`, `--enable-analyzer`, `--disable-analyzer` |
+| `bump` | Apply a specific version bump | `--level`, `--pyproject`, `--format`, `--commit`, `--tag`, `--enable-analyzer`, `--disable-analyzer` |
 
 1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:
 
@@ -51,6 +51,9 @@ pip install bumpwright
    cli = true      # enable CLI analysis
    web_routes = false  # disable route analysis
    ```
+
+   Command-line flags ``--enable-analyzer`` and ``--disable-analyzer`` can
+   temporarily override these settings for a single invocation.
 
 2. **Suggest the next version** between two git references:
 

--- a/docs/analyzers/index.rst
+++ b/docs/analyzers/index.rst
@@ -13,6 +13,9 @@ Enable optional analysers in ``bumpwright.toml``:
    [migrations]
    paths = ["migrations"]
 
+You can also toggle analysers per invocation with the command-line flags
+``--enable-analyzer`` and ``--disable-analyzer``.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -96,7 +96,8 @@ Analysers
 ~~~~~~~~~
 
 Each key under ``[analyzers]`` toggles a plugin. Unknown names raise an error
-at run time. Built-in analysers include:
+at run time. Command-line flags ``--enable-analyzer`` and ``--disable-analyzer``
+temporarily override these settings. Built-in analysers include:
 
 .. list-table:: Available analysers
    :header-rows: 1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,12 @@ require.
 ``--repo-url URL``
     Base repository URL for linking commit hashes in Markdown output.
 
+``--enable-analyzer NAME``
+    Enable analyzer ``NAME`` in addition to configuration. Repeatable.
+
+``--disable-analyzer NAME``
+    Disable analyzer ``NAME`` even if enabled in configuration. Repeatable.
+
 **Examples**
 
 .. code-block:: console
@@ -120,6 +126,12 @@ assignment. These locations can be customised via the ``[version]`` section in
 
 ``--repo-url URL``
     Base repository URL for linking commit hashes in Markdown output.
+
+``--enable-analyzer NAME``
+    Enable analyzer ``NAME`` in addition to configuration. Repeatable.
+
+``--disable-analyzer NAME``
+    Disable analyzer ``NAME`` even if enabled in configuration. Repeatable.
 
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to

--- a/tests/test_cli_analyzer_flags.py
+++ b/tests/test_cli_analyzer_flags.py
@@ -1,0 +1,102 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.cli_helpers import run, setup_repo
+
+
+def _setup_cli_repo(
+    tmp_path: Path, enable_in_config: bool = False
+) -> tuple[Path, str, str]:
+    """Create a repository with a CLI command that is later removed."""
+    repo, pkg, _ = setup_repo(tmp_path)
+    if enable_in_config:
+        (repo / "bumpwright.toml").write_text(
+            """[project]\npublic_roots=['pkg']\n[analyzers]\ncli = true\n""",
+            encoding="utf-8",
+        )
+        run(["git", "add", "bumpwright.toml"], repo)
+    (pkg / "cli.py").write_text(
+        """import argparse
+parser = argparse.ArgumentParser()
+sub = parser.add_subparsers()
+p_run = sub.add_parser('run')
+""",
+        encoding="utf-8",
+    )
+    run(["git", "add", "pkg/cli.py"], repo)
+    run(["git", "commit", "-m", "add cli"], repo)
+    base = run(["git", "rev-parse", "HEAD"], repo)
+    (pkg / "cli.py").write_text(
+        """import argparse
+parser = argparse.ArgumentParser()
+sub = parser.add_subparsers()
+""",
+        encoding="utf-8",
+    )
+    run(["git", "add", "pkg/cli.py"], repo)
+    run(["git", "commit", "-m", "drop cli"], repo)
+    head = run(["git", "rev-parse", "HEAD"], repo)
+    return repo, base, head
+
+
+def test_enable_analyzer_flag(tmp_path: Path) -> None:
+    """CLI flag enables an analyzer not set in configuration."""
+    repo, base, head = _setup_cli_repo(tmp_path)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+            "--enable-analyzer",
+            "cli",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    data = json.loads(res.stdout)
+    assert data["level"] == "major"
+
+
+def test_disable_analyzer_flag(tmp_path: Path) -> None:
+    """CLI flag disables an analyzer configured in the project."""
+    repo, base, head = _setup_cli_repo(tmp_path, enable_in_config=True)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--format",
+            "json",
+            "--disable-analyzer",
+            "cli",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    data = json.loads(res.stdout)
+    assert data["level"] is None


### PR DESCRIPTION
## Summary
- add CLI flags to enable or disable analyzers, overriding config
- document analyzer toggling in README and guides
- test analyzer selection via command-line flags

## Testing
- `python -m isort --profile black --check-only bumpwright/cli.py tests/test_cli_analyzer_flags.py docs/usage.rst docs/configuration.rst docs/analyzers/index.rst README.md`
- `python -m black bumpwright/cli.py tests/test_cli_analyzer_flags.py`
- `ruff check bumpwright/cli.py tests/test_cli_analyzer_flags.py`
- `pytest`

Labels: feat

------
https://chatgpt.com/codex/tasks/task_e_68a05942f95c8322815c38dd8481269d