### PR TITLE
feat(cli): expose parser factory and document CLI

### DIFF
--- a/bumpwright/cli.py
+++ b/bumpwright/cli.py
@@ -424,14 +424,11 @@ def bump_command(args: argparse.Namespace) -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Entry point for the ``bumpwright`` CLI.
-
-    Args:
-        argv: Optional argument vector.
+def get_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the command-line interface.
 
     Returns:
-        Process exit code.
+        Configured :class:`argparse.ArgumentParser` instance.
     """
 
     avail = ", ".join(available()) or "none"
@@ -514,9 +511,7 @@ def main(argv: list[str] | None = None) -> int:
         "--version-ignore",
         action="append",
         dest="version_ignore",
-        help=(
-            "Glob pattern for paths to exclude from version updates " "(repeatable)."
-        ),
+        help=("Glob pattern for paths to exclude from version updates (repeatable)."),
     )
     p_bump.add_argument(
         "--commit",
@@ -538,7 +533,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Append release notes to FILE or stdout when no path is given.",
     )
     p_bump.set_defaults(func=bump_command)
+    return parser
 
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``bumpwright`` CLI.
+
+    Args:
+        argv: Optional argument vector.
+
+    Returns:
+        Process exit code.
+    """
+
+    parser = get_parser()
     args = parser.parse_args(argv)
     if not hasattr(args, "func"):
         parser.print_help()

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -1,0 +1,7 @@
+CLI reference
+=============
+
+.. argparse::
+   :module: bumpwright.cli
+   :func: get_parser
+   :prog: bumpwright

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx_argparse",
     "sphinx_wagtail_theme",
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Static public-API diff and heuristics to suggest semantic version bumps.
 
    installation
    usage
+   cli_reference
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ docs = [
   "sphinx-wagtail-theme",
   "sphinx-autodoc-typehints>=2.2",
   "sphinx-copybutton>=0.5.2",
-  "myst-parser"
+  "myst-parser",
+  "sphinx-argparse"
 ]
 dev = [
   "pytest>=8.2",

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,0 +1,10 @@
+from argparse import ArgumentParser
+
+from bumpwright.cli import get_parser
+
+
+def test_get_parser_returns_argument_parser() -> None:
+    """Ensure ``get_parser`` creates the CLI parser."""
+    parser = get_parser()
+    assert isinstance(parser, ArgumentParser)
+    assert parser.prog == "bumpwright"


### PR DESCRIPTION
## Summary
- expose `get_parser` factory for CLI
- document command-line options with sphinx-argparse

## Testing
- `python -m isort --profile=black --check-only -v bumpwright/cli.py tests/test_cli_parser.py`
- `python -m black bumpwright/cli.py tests/test_cli_parser.py`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a05b100fc48322a7b411ec1a380798