### PR TITLE
docs(configuration): sync defaults with _DEFAULTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ web_routes = false
 paths = ["migrations"]
 
 [changelog]
-path = "CHANGELOG.md"
+path = ""
 
 [version]
-paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]
+paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]
 ignore = []
 ```
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -30,7 +30,7 @@ Example configuration showing all available sections and their default values:
    path = ""
 
    [version]
-   paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/*.py"]
+   paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]
    ignore = []
 
 Set an analyser value to ``true`` to enable it.


### PR DESCRIPTION
## Summary
- align changelog and version path defaults in README and configuration reference with `_DEFAULTS`

## Testing
- `ruff check .`
- `black --check .`
- `isort README.md docs/configuration.rst --check-only`
- `pytest`
- `python -m markdown README.md`
- `python -m docutils.core --writer html docs/configuration.rst`
- `sphinx-build -b html docs docs/_build` *(fails: AttributeError: 'function' object has no attribute 'prog')*

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a060720e4c8322b14ec3da9704d2a9