### PR TITLE
docs(modules): add concise module docstrings

### DIFF
--- a/bumpwright/analyzers/cli.py
+++ b/bumpwright/analyzers/cli.py
@@ -1,4 +1,4 @@
-"""CLI analyzer for argparse and click based applications."""
+"""Extract CLI command definitions for argparse and Click applications."""
 
 from __future__ import annotations
 

--- a/bumpwright/analyzers/web_routes.py
+++ b/bumpwright/analyzers/web_routes.py
@@ -1,6 +1,4 @@
-"""Scan Python sources for framework-specific route decorators and compare
-HTTP endpoints across git references to identify breaking or compatible route
-changes."""
+"""Analyze HTTP route decorators to compare endpoints across git references."""
 
 from __future__ import annotations
 

--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -1,4 +1,4 @@
-"""Helpers for reading and bumping package versions."""
+"""Utilities to read and bump project version numbers."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add module docstrings for CLI analyzer, web routes analyzer, and versioning utilities

## Testing
- `isort -v bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/versioning.py`
- `black bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/versioning.py`
- `ruff check bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/versioning.py`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a0607b53948322bc7fccbd2f7a9f1b