### PR TITLE
fix(config): deep copy defaults to prevent mutation

### DIFF
--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -6,6 +6,7 @@ try:  # pragma: no cover - exercised in Python <3.11 tests
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
+import copy
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -138,7 +139,7 @@ def _merge_defaults(data: dict | None) -> dict:
         Combined configuration with defaults applied.
     """
 
-    out = {k: dict(v) for k, v in _DEFAULTS.items()}
+    out = copy.deepcopy(_DEFAULTS)  # Deep clone to avoid shared mutable defaults.
     for section, content in (data or {}).items():
         out.setdefault(section, {}).update(content or {})
     return out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,3 +48,16 @@ def test_tomli_fallback(monkeypatch, tmp_path: Path) -> None:
     assert config.tomllib is tomli
     cfg = config.load_config(tmp_path / "missing.toml")
     assert cfg.project.index_file == "pyproject.toml"
+
+
+def test_mutating_config_does_not_alter_defaults(tmp_path: Path) -> None:
+    """Ensure modifying a loaded config leaves defaults unchanged."""
+
+    cfg = load_config(tmp_path / "missing.toml")
+    cfg.project.public_roots.append("src")
+
+    import bumpwright.config as config_module
+
+    fresh = load_config(tmp_path / "missing.toml")
+    assert config_module._DEFAULTS["project"]["public_roots"] == ["."]
+    assert fresh.project.public_roots == ["."]


### PR DESCRIPTION
## Summary
- deep copy configuration defaults to avoid shared mutable state
- add regression test ensuring mutations don't alter defaults

## Testing
- `isort bumpwright/config.py tests/test_config.py`
- `black bumpwright/config.py tests/test_config.py`
- `ruff check bumpwright/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a061ff32f883228516ba51523a719f