### PR TITLE
docs(workflow): showcase automatic version bump in GitHub Actions

### DIFF
--- a/docs/_static/workflows/bumpwright-auto-bump.yml
+++ b/docs/_static/workflows/bumpwright-auto-bump.yml
@@ -1,0 +1,25 @@
+name: bumpwright auto bump
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install bumpwright
+        run: pip install bumpwright
+      - name: Bump version and update changelog
+        run: |
+          bumpwright bump --decide --pyproject pyproject.toml --changelog CHANGELOG.md --commit --tag
+      - name: Push changes
+        run: git push origin HEAD --follow-tags

--- a/docs/guides/workflows.rst
+++ b/docs/guides/workflows.rst
@@ -1,10 +1,22 @@
 GitHub Actions workflows
 ========================
 
-Bumpwright integrates easily with GitHub Actions. The example workflows below
-show how to suggest the next semantic version and how to apply a release.
-Place these files in the ``.github/workflows`` directory of your project to
-use them.
+Bumpwright integrates easily with GitHub Actions. The workflows below show
+how to automatically apply a version bump on pushes to your main branch,
+suggest the next semantic version, and run a manual release. Place these files
+in the ``.github/workflows`` directory of your project to use them.
+
+Automatic version bump on push
+------------------------------
+
+The ``bumpwright-auto-bump.yml`` workflow updates your project version and
+changelog whenever new commits land on ``main`` or ``master``.
+
+.. literalinclude:: ../_static/workflows/bumpwright-auto-bump.yml
+   :language: yaml
+   :caption: bumpwright-auto-bump.yml
+
+Download the file: :download:`bumpwright-auto-bump.yml <../_static/workflows/bumpwright-auto-bump.yml>`.
 
 Pull request check
 ------------------
@@ -19,8 +31,8 @@ event, or adapt it to run on pull requests.
 
 Download the file: :download:`bumpwright-check.yml <../_static/workflows/bumpwright-check.yml>`.
 
-Release automation
-------------------
+Manual release automation
+-------------------------
 
 The ``bumpwright-release.yml`` workflow applies a version bump, commits the
 updated files, and pushes a tag. Provide the desired bump level when triggering


### PR DESCRIPTION
## Summary
- document automatic version and changelog bumps when pushing to `main` or `master`
- add sample `bumpwright-auto-bump.yml` workflow file

## Testing
- `ruff check --fix .`
- `isort .`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0626dd0788322a4a9a0efe2d182ac