### PR TITLE
docs(cli): call get_parser in autoprogram directive

### DIFF
--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -1,5 +1,5 @@
 CLI reference
 =============
 
-.. autoprogram:: bumpwright.cli:get_parser
+.. autoprogram:: bumpwright.cli:get_parser()
    :prog: bumpwright


### PR DESCRIPTION
## Summary
- fix Sphinx CLI reference generation by calling `get_parser`

## Testing
- `ruff check .`
- `black .`
- `isort .`
- `sphinx-build -b html docs docs/_build/html`
- `PYTHONPATH=tests pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a062ff10608322a4fd0c8cf445699f