### PR TITLE
docs(cli): fix CLI reference parser import

### DIFF
--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -1,5 +1,5 @@
 CLI reference
 =============
 
-.. autoprogram:: bumpwright.cli:get_parser
+.. autoprogram:: bumpwright.cli:get_parser()
    :prog: bumpwright

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,9 @@ import os
 import sys
 from datetime import datetime
 
+# Ensure project root on path so bumpwright can be imported when building docs
+sys.path.insert(0, os.path.abspath(".."))
+
 import bumpwright
 
 project = "bumpwright"


### PR DESCRIPTION
## Summary
- ensure Sphinx can import project package
- call `get_parser()` in CLI reference so autoprogram uses built parser

## Testing
- `ruff check .`
- `isort --check --diff docs/conf.py`
- `black docs/conf.py`
- `sphinx-build -b html docs docs/_build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0661d8be883228e0233ec32cafa35