### PR TITLE
feat(compare): return decision confidence and reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,18 @@ pip install bumpwright
 
    ```console
    $ bumpwright bump --decide --base origin/main --head HEAD --format json
-   {"level": "minor", "changes": [{"severity": "minor", "symbol": "cli.new_command", "description": "added CLI entry 'greet'"}]}
+   {
+     "level": "minor",
+     "confidence": 1.0,
+     "reasons": ["added CLI entry 'greet'"],
+     "impacts": [
+       {"severity": "minor", "symbol": "cli.new_command", "reason": "added CLI entry 'greet'"}
+     ]
+   }
    ```
+
+   The ``confidence`` value indicates the proportion of impacts that triggered
+   the suggested level, while ``reasons`` summarise those impacts.
 
    If ``--base`` is omitted, the command compares the current commit to its
    immediate parent (``HEAD^``).

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -69,10 +69,15 @@ require.
 
    {
      "level": "minor",
+     "confidence": 1.0,
+     "reasons": ["added CLI entry 'greet'"],
      "impacts": [
        {"severity": "minor", "symbol": "cli.new_command", "reason": "added CLI entry 'greet'"}
      ]
    }
+
+The ``confidence`` value reflects the proportion of impacts that led to the
+suggested level, while ``reasons`` summarise those impacts.
 
 Running ``bumpwright bump --decide`` without ``--base`` compares the current
 commit against the last release commit or, if none exists, its parent (``HEAD^``).

--- a/tests/test_cli_analyzer_flags.py
+++ b/tests/test_cli_analyzer_flags.py
@@ -70,6 +70,8 @@ def test_enable_analyzer_flag(tmp_path: Path) -> None:
     )
     data = json.loads(res.stdout)
     assert data["level"] == "major"
+    assert data["confidence"] == 1.0
+    assert data["reasons"] == ["Removed command"]
 
 
 def test_disable_analyzer_flag(tmp_path: Path) -> None:
@@ -100,3 +102,5 @@ def test_disable_analyzer_flag(tmp_path: Path) -> None:
     )
     data = json.loads(res.stdout)
     assert data["level"] is None
+    assert data["confidence"] == 0.0
+    assert data["reasons"] == []

--- a/tests/test_cli_bump_decide_parity.py
+++ b/tests/test_cli_bump_decide_parity.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -29,6 +30,27 @@ def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
         env=env,
     )
     assert "Suggested bump: None" in res_decide.stdout
+
+    res_decide_json = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--decide",
+            "--format",
+            "json",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    data = json.loads(res_decide_json.stdout)
+    assert data["level"] is None
+    assert data["confidence"] == 0.0
+    assert data["reasons"] == []
 
     res_bump = subprocess.run(
         [sys.executable, "-m", "bumpwright.cli", "bump"],

--- a/tests/test_cli_bump_format.py
+++ b/tests/test_cli_bump_format.py
@@ -35,3 +35,5 @@ def test_bump_command_json_format(tmp_path: Path) -> None:
     assert data["old_version"] == "0.1.0"
     assert data["new_version"] == "0.2.0"
     assert data["level"] == "minor"
+    assert data["confidence"] == 1.0
+    assert data["reasons"] == []

--- a/tests/test_cli_decide_default.py
+++ b/tests/test_cli_decide_default.py
@@ -33,3 +33,5 @@ def test_decide_flag_defaults_to_previous_commit(tmp_path: Path) -> None:
 
     data = json.loads(res.stdout)
     assert data["level"] == "minor"
+    assert data["confidence"] == 1.0
+    assert data["reasons"] == ["Added public symbol"]


### PR DESCRIPTION
## Summary
- expand bump decision to include confidence ratios and reasoning
- surface decision details in CLI JSON output
- document enriched decision payload

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a066c857948322a933fbab141e663e