### PR TITLE
feat(gitutils): cache list_py_files_at_ref results

### DIFF
--- a/tests/test_gitutils.py
+++ b/tests/test_gitutils.py
@@ -55,6 +55,33 @@ def test_list_py_files_at_ref_matches_legacy(tmp_path):
     assert result == expected
 
 
+def test_list_py_files_at_ref_caches(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "__init__.py").write_text("\n")
+    gitutils._run(["git", "init"], str(repo))
+    gitutils._run(["git", "config", "user.email", "test@example.com"], str(repo))
+    gitutils._run(["git", "config", "user.name", "Test"], str(repo))
+    gitutils._run(["git", "add", "."], str(repo))
+    gitutils._run(["git", "commit", "-m", "init"], str(repo))
+
+    gitutils.list_py_files_at_ref.cache_clear()
+    original = gitutils._run
+    calls: list[list[str]] = []
+
+    def spy(cmd: list[str], cwd: str | None = None) -> str:
+        if cmd[:3] == ["git", "ls-tree", "-r"]:
+            calls.append(cmd)
+        return original(cmd, cwd)
+
+    monkeypatch.setattr(gitutils, "_run", spy)
+    gitutils.list_py_files_at_ref("HEAD", ["."], cwd=str(repo))
+    gitutils.list_py_files_at_ref("HEAD", ["."], cwd=str(repo))
+    assert len(calls) == 1
+    gitutils.list_py_files_at_ref.cache_clear()
+
+
 def test_collect_commits(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- cache `list_py_files_at_ref` results and expose cache clearing
- test that `list_py_files_at_ref` hits cache on repeated calls

## Testing
- `ruff check bumpwright/gitutils.py tests/test_gitutils.py`
- `black bumpwright/gitutils.py tests/test_gitutils.py`
- `isort bumpwright/gitutils.py tests/test_gitutils.py`
- `pytest`
- `python - <<'PY'
import time
from bumpwright.gitutils import list_py_files_at_ref

start = time.perf_counter()
list_py_files_at_ref("HEAD", ["bumpwright"], cwd=None)
first = time.perf_counter() - start
start = time.perf_counter()
list_py_files_at_ref("HEAD", ["bumpwright"], cwd=None)
second = time.perf_counter() - start
print(f"first: {first:.6f}s, second: {second:.6f}s, speedup: {first/second if second else float('inf'):.2f}x")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a068a834148322b8c61624993bf6a8