### PR TITLE
refactor(analyzers): centralize python file retrieval

### DIFF
--- a/bumpwright/analyzers/cli.py
+++ b/bumpwright/analyzers/cli.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 
 from ..compare import Impact
 from ..config import Config
-from ..gitutils import list_py_files_at_ref, read_file_at_ref
 from . import register
+from .utils import iter_py_files_at_ref
 
 
 @dataclass(frozen=True)
@@ -227,10 +227,7 @@ def _build_cli_at_ref(
     """
 
     out: dict[str, Command] = {}
-    for path in list_py_files_at_ref(ref, roots, ignore_globs=ignores):
-        code = read_file_at_ref(ref, path)
-        if code is None:
-            continue
+    for _path, code in iter_py_files_at_ref(ref, roots, ignores):
         out.update(extract_cli_from_source(code))
     return out
 

--- a/bumpwright/analyzers/utils.py
+++ b/bumpwright/analyzers/utils.py
@@ -1,0 +1,31 @@
+"""Shared helpers for analyzer modules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from ..gitutils import list_py_files_at_ref, read_file_at_ref
+
+
+def iter_py_files_at_ref(
+    ref: str,
+    roots: Iterable[str],
+    ignore_globs: Iterable[str] | None = None,
+    cwd: str | None = None,
+) -> Iterator[tuple[str, str]]:
+    """Yield Python file paths and contents for a git reference.
+
+    Args:
+        ref: Git reference to inspect.
+        roots: Root directories to search for Python modules.
+        ignore_globs: Optional glob patterns to exclude.
+        cwd: Repository path in which to run git commands.
+
+    Yields:
+        Tuples of ``(path, source)`` for each discovered Python file.
+    """
+
+    for path in list_py_files_at_ref(ref, roots, ignore_globs=ignore_globs, cwd=cwd):
+        code = read_file_at_ref(ref, path, cwd=cwd)
+        if code is not None:
+            yield path, code

--- a/bumpwright/analyzers/web_routes.py
+++ b/bumpwright/analyzers/web_routes.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 
 from ..compare import Impact
 from ..config import Config
-from ..gitutils import list_py_files_at_ref, read_file_at_ref
 from . import register
+from .utils import iter_py_files_at_ref
 
 HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
 
@@ -114,10 +114,7 @@ def _build_routes_at_ref(
     """
 
     out: dict[tuple[str, str], Route] = {}
-    for path in list_py_files_at_ref(ref, roots, ignore_globs=ignores):
-        code = read_file_at_ref(ref, path)
-        if code is None:
-            continue
+    for _path, code in iter_py_files_at_ref(ref, roots, ignores):
         out.update(extract_routes_from_source(code))
     return out
 

--- a/bumpwright/cli/decide.py
+++ b/bumpwright/cli/decide.py
@@ -9,9 +9,10 @@ import subprocess
 from collections.abc import Iterable
 
 from ..analyzers import get_analyzer_info
+from ..analyzers.utils import iter_py_files_at_ref
 from ..compare import Decision, Impact, decide_bump, diff_public_api
 from ..config import Config
-from ..gitutils import last_release_commit, list_py_files_at_ref, read_file_at_ref
+from ..gitutils import last_release_commit
 from ..public_api import (
     PublicAPI,
     extract_public_api_from_source,
@@ -26,10 +27,9 @@ def _build_api_at_ref(ref: str, roots: list[str], ignores: Iterable[str]) -> Pub
 
     api: PublicAPI = {}
     for root in roots:
-        for path in sorted(list_py_files_at_ref(ref, [root], ignore_globs=ignores)):
-            code = read_file_at_ref(ref, path)
-            if code is None:
-                continue
+        for path, code in sorted(
+            iter_py_files_at_ref(ref, [root], ignores), key=lambda t: t[0]
+        ):
             modname = module_name_from_path(root, path)
             api.update(extract_public_api_from_source(modname, code))
     return api

--- a/tests/test_analyzers_utils.py
+++ b/tests/test_analyzers_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from bumpwright import gitutils
+from bumpwright.analyzers.utils import iter_py_files_at_ref
+
+
+def test_iter_py_files_at_ref(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pkg = repo / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("a = 1\n")
+    (pkg / "mod.py").write_text("b = 2\n")
+    gitutils._run(["git", "init"], str(repo))
+    gitutils._run(["git", "config", "user.email", "test@example.com"], str(repo))
+    gitutils._run(["git", "config", "user.name", "Test"], str(repo))
+    gitutils._run(["git", "add", "."], str(repo))
+    gitutils._run(["git", "commit", "-m", "init"], str(repo))
+
+    files = dict(iter_py_files_at_ref("HEAD", ["pkg"], [], str(repo)))
+    assert files["pkg/__init__.py"] == "a = 1\n"
+    assert files["pkg/mod.py"] == "b = 2\n"
+
+    files = dict(iter_py_files_at_ref("HEAD", ["pkg"], ["pkg/mod.py"], str(repo)))
+    assert set(files) == {"pkg/__init__.py"}


### PR DESCRIPTION
## Summary
- add iter_py_files_at_ref utility for analyzer modules
- refactor CLI analyzer, web route analyzer and CLI decision helpers to use shared util
- test coverage for file iterator

## Testing
- `python -m ruff check tests/test_analyzers_utils.py bumpwright/analyzers/utils.py bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/cli/decide.py`
- `python -m black tests/test_analyzers_utils.py bumpwright/analyzers/utils.py bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/cli/decide.py`
- `python -m isort tests/test_analyzers_utils.py bumpwright/analyzers/utils.py bumpwright/analyzers/cli.py bumpwright/analyzers/web_routes.py bumpwright/cli/decide.py`
- `pytest`

## Labels
- refactor

------
https://chatgpt.com/codex/tasks/task_e_68a06bedf44c8322ba25ff94ae00a71e