### PR TITLE
feat(compare): add severity type for API impacts

### DIFF
--- a/bumpwright/analyzers/cli.py
+++ b/bumpwright/analyzers/cli.py
@@ -6,7 +6,7 @@ import ast
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from ..compare import Impact
+from ..compare import Impact, Severity
 from ..config import Config
 from . import register
 from .utils import iter_py_files_at_ref
@@ -197,11 +197,11 @@ def diff_cli(old: dict[str, Command], new: dict[str, Command]) -> list[Impact]:
         op = old[name].options
         np = new[name].options
         for opt in op.keys() - np.keys():
-            severity = "major" if op[opt] else "minor"
+            severity: Severity = "major" if op[opt] else "minor"
             reason = "Removed required option" if op[opt] else "Removed optional option"
             impacts.append(Impact(severity, name, f"{reason} '{opt}'"))
         for opt in np.keys() - op.keys():
-            severity = "major" if np[opt] else "minor"
+            severity: Severity = "major" if np[opt] else "minor"
             reason = "Added required option" if np[opt] else "Added optional option"
             impacts.append(Impact(severity, name, f"{reason} '{opt}'"))
         for opt in op.keys() & np.keys():

--- a/bumpwright/compare.py
+++ b/bumpwright/compare.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
+from typing import Literal
 
 from .public_api import FuncSig, Param, PublicAPI
+
+# Severity levels for public API changes
+Severity = Literal["major", "minor", "patch"]
 
 
 @dataclass(frozen=True)
@@ -18,7 +22,7 @@ class Impact:
         reason: Human-friendly explanation of the change.
     """
 
-    severity: str  # "major" | "minor" | "patch"
+    severity: Severity
     symbol: str
     reason: str
 
@@ -35,7 +39,7 @@ class Decision:
             decision.
     """
 
-    level: str | None
+    level: Severity | None
     confidence: float
     reasons: list[str]
 
@@ -53,7 +57,9 @@ def _index_params(sig: FuncSig) -> dict[str, Param]:
     return {p.name: p for p in sig.params}
 
 
-def compare_funcs(old: FuncSig, new: FuncSig, return_type_change: str = "minor") -> list[Impact]:
+def compare_funcs(
+    old: FuncSig, new: FuncSig, return_type_change: Severity = "minor"
+) -> list[Impact]:
     """Compare two function signatures and record API impacts.
 
     Args:
@@ -74,19 +80,26 @@ def compare_funcs(old: FuncSig, new: FuncSig, return_type_change: str = "minor")
     for name, op in oldp.items():
         if name not in newp:
             if op.kind in ("posonly", "pos", "kwonly") and op.default is None:
-                impacts.append(Impact("major", old.fullname, f"Removed required param '{name}'"))
+                impacts.append(
+                    Impact("major", old.fullname, f"Removed required param '{name}'")
+                )
             elif op.default is not None or op.kind in (
                 "kwonly",
                 "vararg",
                 "varkw",
             ):
-                impacts.append(Impact("minor", old.fullname, f"Removed optional param '{name}'"))
+                impacts.append(
+                    Impact("minor", old.fullname, f"Removed optional param '{name}'")
+                )
 
     # Param kind changes are major; added params are major if required otherwise minor
     for name, np in newp.items():
         if name in oldp:
             op = oldp[name]
-            if op.kind != np.kind and (op.kind in ("posonly", "pos", "kwonly") or np.kind in ("posonly", "pos", "kwonly")):
+            if op.kind != np.kind and (
+                op.kind in ("posonly", "pos", "kwonly")
+                or np.kind in ("posonly", "pos", "kwonly")
+            ):
                 impacts.append(
                     Impact(
                         "major",
@@ -95,18 +108,26 @@ def compare_funcs(old: FuncSig, new: FuncSig, return_type_change: str = "minor")
                     )
                 )
         elif np.default is None and np.kind in ("posonly", "pos", "kwonly"):
-            impacts.append(Impact("major", old.fullname, f"Added required param '{name}'"))
+            impacts.append(
+                Impact("major", old.fullname, f"Added required param '{name}'")
+            )
         else:
-            impacts.append(Impact("minor", old.fullname, f"Added optional param '{name}'"))
+            impacts.append(
+                Impact("minor", old.fullname, f"Added optional param '{name}'")
+            )
 
     # Return annotation change -> configurable severity
     if old.returns != new.returns:
-        impacts.append(Impact(return_type_change, old.fullname, "Return annotation changed"))
+        impacts.append(
+            Impact(return_type_change, old.fullname, "Return annotation changed")
+        )
 
     return impacts
 
 
-def diff_public_api(old: PublicAPI, new: PublicAPI, return_type_change: str = "minor") -> list[Impact]:
+def diff_public_api(
+    old: PublicAPI, new: PublicAPI, return_type_change: Severity = "minor"
+) -> list[Impact]:
     """Compute impacts between two public API mappings.
 
     Args:
@@ -126,7 +147,9 @@ def diff_public_api(old: PublicAPI, new: PublicAPI, return_type_change: str = "m
 
     # Surviving symbols
     for k in old.keys() & new.keys():
-        impacts.extend(compare_funcs(old[k], new[k], return_type_change=return_type_change))
+        impacts.extend(
+            compare_funcs(old[k], new[k], return_type_change=return_type_change)
+        )
 
     # Added symbols
     for k in new.keys() - old.keys():
@@ -148,10 +171,10 @@ def decide_bump(impacts: list[Impact]) -> Decision:
     if not impacts:
         return Decision(None, 0.0, [])
 
-    counts = Counter(i.severity for i in impacts)
+    counts: Counter[Severity] = Counter(i.severity for i in impacts)
     total = sum(counts.values())
     if counts.get("major"):
-        level = "major"
+        level: Severity = "major"
     elif counts.get("minor"):
         level = "minor"
     else:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,5 +1,14 @@
-from bumpwright.compare import Impact, compare_funcs, decide_bump, diff_public_api
+from bumpwright.compare import (
+    Impact,
+    Severity,
+    compare_funcs,
+    decide_bump,
+    diff_public_api,
+)
 from bumpwright.public_api import FuncSig, Param
+
+MAJOR: Severity = "major"
+MINOR: Severity = "minor"
 
 
 def _sig(name, params, returns=None):
@@ -14,21 +23,21 @@ def test_added_optional_param_is_minor():
     old = _sig("m:f", [_p("x")], "-> int")
     new = _sig("m:f", [_p("x"), _p("timeout", kind="kwonly", default="None")], "-> int")
     impacts = compare_funcs(old, new)
-    assert any(i.severity == "minor" for i in impacts)
+    assert any(i.severity == MINOR for i in impacts)
 
 
 def test_added_required_param_is_major():
     old = _sig("m:f", [_p("x")], "-> int")
     new = _sig("m:f", [_p("x"), _p("y")], "-> int")
     impacts = compare_funcs(old, new)
-    assert any(i.severity == "major" for i in impacts)
+    assert any(i.severity == MAJOR for i in impacts)
 
 
 def test_removed_required_param_is_major():
     old = _sig("m:f", [_p("x"), _p("y")], None)
     new = _sig("m:f", [_p("x")], None)
     impacts = compare_funcs(old, new)
-    assert any(i.severity == "major" for i in impacts)
+    assert any(i.severity == MAJOR for i in impacts)
 
 
 def test_removed_optional_param_is_minor():
@@ -39,16 +48,16 @@ def test_removed_optional_param_is_minor():
     )
     new = _sig("m:f", [_p("x")], "-> int")
     impacts = compare_funcs(old, new)
-    assert any(i.severity == "minor" for i in impacts)
+    assert any(i.severity == MINOR for i in impacts)
 
 
 def test_removed_symbol_is_major():
     old = {"m:f": _sig("m:f", [_p("x")], None)}
     new = {}
     impacts = diff_public_api(old, new)
-    assert any(i.severity == "major" for i in impacts)
+    assert any(i.severity == MAJOR for i in impacts)
     decision = decide_bump(impacts)
-    assert decision.level == "major"
+    assert decision.level == MAJOR
     assert decision.confidence == 1.0
     assert decision.reasons == ["Removed public symbol"]
 
@@ -57,8 +66,8 @@ def test_confidence_ratio():
     old = {"m:f": _sig("m:f", [_p("x")], None)}
     new = {"m:f": _sig("m:f", [_p("x"), _p("y")], None)}
     impacts = diff_public_api(old, new)
-    impacts.append(Impact("minor", "m:g", "Added public symbol"))
+    impacts.append(Impact(MINOR, "m:g", "Added public symbol"))
     decision = decide_bump(impacts)
-    assert decision.level == "major"
+    assert decision.level == MAJOR
     assert decision.confidence == 0.5
     assert decision.reasons == ["Added required param 'y'"]


### PR DESCRIPTION
## Summary
- define a dedicated `Severity` type for version-impact classification
- use `Severity` across comparison helpers and CLI analyzer
- update comparison tests to exercise `Severity`

## Testing
- `python -m isort bumpwright/compare.py bumpwright/analyzers/cli.py tests/test_compare.py`
- `python -m black bumpwright/compare.py bumpwright/analyzers/cli.py tests/test_compare.py`
- `python -m ruff check bumpwright/compare.py bumpwright/analyzers/cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06f3c8edc832285a04c116a2698d4