### PR TITLE
test(versioning): add resolve files path handling tests

### DIFF
--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,7 +4,12 @@ import pytest
 from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
-from bumpwright.versioning import apply_bump, bump_string, read_project_version
+from bumpwright.versioning import (
+    _resolve_files,
+    apply_bump,
+    bump_string,
+    read_project_version,
+)
 
 
 def test_bump_string():
@@ -117,3 +122,54 @@ def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
     out = apply_bump("minor", py, ignore=[str(init)])
     assert "__version__ = '1.0.0'" in init.read_text(encoding="utf-8")
     assert init not in out.files
+
+
+def test_resolve_files_nested_dirs_sorted(tmp_path: Path) -> None:
+    """Resolve nested patterns and ensure results are deterministically ordered."""
+
+    pkg = tmp_path / "pkg"
+    sub = pkg / "sub"
+    sub.mkdir(parents=True)
+
+    # Create files in non-sorted order to verify output sorting.
+    paths = [
+        pkg / "b.txt",
+        pkg / "a.txt",
+        sub / "d.txt",
+        sub / "c.txt",
+    ]
+    for path in paths:
+        path.write_text("", encoding="utf-8")
+
+    out = _resolve_files(["pkg/**/*.txt"], [], tmp_path)
+    expected = [
+        pkg / "a.txt",
+        pkg / "b.txt",
+        sub / "c.txt",
+        sub / "d.txt",
+    ]
+    assert out == expected
+
+
+def test_resolve_files_absolute_paths_and_ignore_patterns(tmp_path: Path) -> None:
+    """Handle absolute patterns and exclusion rules in file resolution."""
+
+    base = tmp_path
+    abs_file = base / "abs.py"
+    abs_file.write_text("", encoding="utf-8")
+
+    ignore_abs = base / "ignore_abs.py"
+    ignore_abs.write_text("", encoding="utf-8")
+
+    pkg = base / "pkg"
+    pkg.mkdir()
+    keep_rel = pkg / "keep.py"
+    keep_rel.write_text("", encoding="utf-8")
+    ignore_rel = pkg / "ignore_rel.py"
+    ignore_rel.write_text("", encoding="utf-8")
+
+    patterns = [str(abs_file), str(ignore_abs), "pkg/*.py"]
+    ignore = [str(ignore_abs), "pkg/ignore_rel.py"]
+    out = _resolve_files(patterns, ignore, base)
+    expected = [abs_file, keep_rel]
+    assert out == expected


### PR DESCRIPTION
## Summary
- add comprehensive tests for `_resolve_files` covering nested directories, absolute paths, and ignore patterns

## Testing
- `isort tests/test_versioning.py`
- `black tests/test_versioning.py`
- `ruff check tests/test_versioning.py`
- `pytest tests/test_versioning.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06f7dc0e88322885daea52b611341