### PR TITLE
docs(quickstart): add quickstart guide and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pip install bumpwright
 ```
 
 ## Quick start
+See [docs/quickstart.rst](docs/quickstart.rst) for a step-by-step example.
+
 | Command | Purpose |
 |---------|---------|
 | `bump --decide` | Recommend a bump between two references |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Static public-API diff and heuristics to suggest semantic version bumps.
    :caption: Getting Started
 
    installation
+   quickstart
    usage
    cli_reference
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,23 @@
+Quickstart
+==========
+
+Follow these steps to start using **bumpwright**:
+
+#. Install the package.
+
+   .. code-block:: bash
+
+      pip install bumpwright
+
+#. Initialise configuration in your project directory.
+
+   .. code-block:: bash
+
+      bumpwright init
+
+#. Recommend the next version.
+
+   .. code-block:: bash
+
+      bumpwright bump --decide
+


### PR DESCRIPTION
## Summary
- add quickstart guide with install/init/bump steps
- link quickstart in main docs index
- reference quickstart guide from README quick start section

## Testing
- `ruff check .`
- `black .`
- `isort .`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a06f89b0cc83229749c5c661b8cdbe