### PR TITLE
docs(cli): document CLI with sphinx-click

### DIFF
--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Click wrappers for documenting the :mod:`bumpwright` CLI."""
+
+import argparse
+
+import click
+
+from bumpwright.cli.bump import bump_command
+from bumpwright.cli.init import init_command
+
+
+@click.group()
+@click.option(
+    "--config",
+    default="bumpwright.toml",
+    show_default=True,
+    help="Path to configuration file. See :doc:`configuration` for details.",
+)
+@click.pass_context
+def cli(ctx: click.Context, config: str) -> None:
+    """Suggest and apply semantic version bumps."""
+
+    ctx.obj = argparse.Namespace(config=config)
+
+
+@cli.command()
+@click.pass_obj
+def init(args: argparse.Namespace) -> int:
+    """Create baseline release commit."""
+
+    return init_command(args)
+
+
+@cli.command()
+@click.option(
+    "--level",
+    type=click.Choice(["major", "minor", "patch"]),
+    help="Desired bump level; if omitted, it is inferred from --base and --head.",
+)
+@click.option(
+    "--base",
+    help=(
+        "Base git reference when auto-deciding the level. Defaults to the last release "
+        "commit or the previous commit (HEAD^)."
+    ),
+)
+@click.option("--head", default="HEAD", show_default=True, help="Head git reference.")
+@click.option(
+    "--format",
+    "format_",
+    type=click.Choice(["text", "md", "json"]),
+    default="text",
+    show_default=True,
+    help="Output style: plain text, Markdown, or machine-readable JSON.",
+)
+@click.option(
+    "--repo-url",
+    help="Base repository URL for linking commit hashes in Markdown output.",
+)
+@click.option(
+    "--decide",
+    is_flag=True,
+    help="Only determine the bump level without modifying any files.",
+)
+@click.option(
+    "--enable-analyzer",
+    multiple=True,
+    help="Enable analyzer NAME (repeatable) in addition to configuration.",
+)
+@click.option(
+    "--disable-analyzer",
+    multiple=True,
+    help="Disable analyzer NAME (repeatable) even if configured.",
+)
+@click.option(
+    "--pyproject",
+    default="pyproject.toml",
+    show_default=True,
+    help="Path to the project's pyproject.toml file.",
+)
+@click.option(
+    "--version-path",
+    multiple=True,
+    help="Additional glob pattern for files containing the project version (repeatable).",
+)
+@click.option(
+    "--version-ignore",
+    multiple=True,
+    help="Glob pattern for paths to exclude from version updates (repeatable).",
+)
+@click.option(
+    "--commit", is_flag=True, help="Create a git commit for the version change."
+)
+@click.option("--tag", is_flag=True, help="Create a git tag for the new version.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Display the new version without modifying any files.",
+)
+@click.option(
+    "--changelog",
+    type=str,
+    help="Append release notes to FILE or stdout when no path is given.",
+)
+@click.pass_obj
+def bump(args: argparse.Namespace, **kwargs: object) -> int:
+    """Update project version metadata and optionally commit and tag the change."""
+
+    params = vars(args).copy()
+    params.update(kwargs)
+    params["enable_analyzer"] = list(params.get("enable_analyzer", []))
+    params["disable_analyzer"] = list(params.get("disable_analyzer", []))
+    params["version_path"] = list(params.get("version_path", []))
+    params["version_ignore"] = list(params.get("version_ignore", []))
+    params["format"] = params.pop("format_")
+    return bump_command(argparse.Namespace(**params))

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -1,5 +1,46 @@
 CLI reference
 =============
 
-.. autoprogram:: bumpwright.cli:get_parser()
+The ``bumpwright`` command-line interface helps manage project version bumps.
+For an introduction see :doc:`usage` and :doc:`configuration`.
+
+Top-level command
+-----------------
+
+.. click:: _bumpwright_click:cli
    :prog: bumpwright
+
+init
+----
+
+Create a baseline release commit.
+
+.. click:: _bumpwright_click:init
+   :prog: bumpwright init
+
+Example:
+
+.. code-block:: console
+
+   $ bumpwright init
+   Created baseline release commit.
+
+bump
+----
+
+Apply a version bump and update project files.
+
+.. click:: _bumpwright_click:bump
+   :prog: bumpwright bump
+
+Example:
+
+.. code-block:: console
+
+   $ bumpwright bump --level patch
+   Bumped version: 0.1.0 -> 0.1.1 (patch)
+   Updated files: pyproject.toml
+
+The ``--config`` option reads from :doc:`configuration`, while
+``--enable-analyzer`` and ``--disable-analyzer`` control optional analysers
+as described in :doc:`analyzers/index`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,9 @@ import os
 import sys
 from datetime import datetime
 
-# Ensure project root on path so bumpwright can be imported when building docs
+# Ensure project root and docs path on sys.path for imports
 sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("."))
 
 import bumpwright
 
@@ -27,7 +28,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_wagtail_theme",
     "sphinx.ext.autosummary",
-    "sphinxcontrib.autoprogram",
     "sphinx.ext.linkcode",
     "sphinx_click",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,14 @@ test = [
   "tomli",
   "click",
 ]
-docs = [
-  "sphinx>=7.3",
-  "sphinx-wagtail-theme",
-  "sphinx-autodoc-typehints>=2.2",
-  "sphinx-copybutton>=0.5.2",
-  "myst-parser",
-  "sphinxcontrib-autoprogram",
-  "sphinx-click",
-]
+  docs = [
+    "sphinx>=7.3",
+    "sphinx-wagtail-theme",
+    "sphinx-autodoc-typehints>=2.2",
+    "sphinx-copybutton>=0.5.2",
+    "myst-parser",
+    "sphinx-click",
+  ]
 dev = [
   "pytest>=8.2",
   "pytest-cov>=5.0",


### PR DESCRIPTION
## Summary
- replace autoprogram with sphinx-click directives and examples
- remove autoprogram extension and dependency

## Testing
- `ruff check .`
- `isort docs/_bumpwright_click.py docs/conf.py pyproject.toml`
- `black docs/_bumpwright_click.py docs/conf.py`
- `sphinx-build -b html docs docs/_build/html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06f8ef8e88322a87cf302c25b60ac