### PR TITLE
docs(quickstart): expand minimal setup and bump example

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-Follow these steps to start using **bumpwright**:
+Start with a tiny example project to see **bumpwright** in action.
 
 #. Install the package.
 
@@ -9,15 +9,77 @@ Follow these steps to start using **bumpwright**:
 
       pip install bumpwright
 
-#. Initialise configuration in your project directory.
+   Install the CLI from PyPI.
+
+#. Create a minimal repository.
+
+   .. code-block:: bash
+
+      mkdir demo && cd demo
+      git init
+      cat > pyproject.toml <<'EOF'
+      [project]
+      name = "demo"
+      version = "0.1.0"
+      EOF
+      git add pyproject.toml
+      git commit -m "chore: initial commit"
+
+   Set up Git and a baseline ``pyproject.toml``. The configuration file
+   shown here is kept intentionally simple; see :doc:`configuration` for
+   detailed options.
+
+#. Initialise configuration.
 
    .. code-block:: bash
 
       bumpwright init
+
+   Records a ``chore(release): initialise baseline`` commit so later runs
+   know where to start. Learn more about this step in :doc:`usage`.
+
+#. Make a change and commit it.
+
+   .. code-block:: bash
+
+      cat > demo.py <<'EOF'
+      def greet() -> str:
+          return "hi"
+      EOF
+      git add demo.py
+      git commit -m "feat: add greet helper"
+
+   This conventional commit describes a new feature, which usually implies a
+   MINOR version bump.
 
 #. Recommend the next version.
 
    .. code-block:: bash
 
       bumpwright bump --decide
+
+   .. code-block:: text
+
+      level  confidence
+      -----  -----------
+      minor  1.00
+
+   ``bumpwright`` inspects commits since the baseline and suggests the next
+   semantic version.
+
+Flow
+----
+
+.. code-block:: text
+
+   Git commit
+       |
+       v
+   bumpwright bump --decide
+       |
+       v
+   Version recommendation
+
+For deeper explanations of commands, flags, and configuration, see
+:doc:`usage` and :doc:`configuration`.
 


### PR DESCRIPTION
## Summary
- expand quickstart with a minimal repository walkthrough
- show `bumpwright init` and `bumpwright bump --decide` with sample output
- add a simple diagram and links to usage and configuration docs

## Testing
- `ruff check .`
- `black --check .` *(fails: 3 files would be reformatted)*
- `isort --check-only .` *(fails: imports not sorted in existing files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0736580008322b2280668a3e35ac2