### PR TITLE
test(compare): import compare utilities

### DIFF
--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,3 +1,5 @@
+"""Tests for public API comparison helpers."""
+
 from bumpwright.compare import (
     Impact,
     Severity,
@@ -9,6 +11,7 @@ from bumpwright.public_api import FuncSig, Param
 
 MAJOR: Severity = "major"
 MINOR: Severity = "minor"
+CONFIDENCE_HALF = 0.5
 
 
 def _sig(name, params, returns=None):
@@ -69,5 +72,5 @@ def test_confidence_ratio():
     impacts.append(Impact(MINOR, "m:g", "Added public symbol"))
     decision = decide_bump(impacts)
     assert decision.level == MAJOR
-    assert decision.confidence == 0.5
+    assert decision.confidence == CONFIDENCE_HALF
     assert decision.reasons == ["Added required param 'y'"]


### PR DESCRIPTION
## Summary
- import compare utilities from `bumpwright.compare`
- document tests and define constant for confidence ratio

## Testing
- `python -m isort tests/test_compare.py`
- `python -m black tests/test_compare.py`
- `python -m ruff check tests/test_compare.py`
- `pytest tests/test_compare.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0738ab80c832292ffdd5e4609c7c9