### PR TITLE
feat!(config): remove unused project.index_file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ all sections and their default values looks like:
 [project]
 package = ""
 public_roots = ["."]
-index_file = "pyproject.toml"
 
 [ignore]
 paths = ["tests/**", "examples/**", "scripts/**"]

--- a/bumpwright.toml
+++ b/bumpwright.toml
@@ -1,7 +1,6 @@
 [project]
 package = "bumpwright"
 public_roots = ["./bumpwright/"]
-index_file = "pyproject.toml"
 
 [ignore]
 paths = ["tests/**", "docs/**", "build/**", ".venv/**"]

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 _DEFAULTS = {
-    "project": {"package": "", "public_roots": ["."], "index_file": "pyproject.toml"},
+    "project": {"package": "", "public_roots": ["."]},
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
     "analysers": {"cli": False},
@@ -40,11 +40,16 @@ class Rules:
 
 @dataclass
 class Project:
-    """Project metadata and locations."""
+    """Project metadata and public API configuration.
+
+    Attributes:
+        package: Importable package containing the project's code. When empty the
+            repository layout is used.
+        public_roots: Paths whose contents constitute the public API.
+    """
 
     package: str = ""
     public_roots: list[str] = field(default_factory=lambda: ["."])
-    index_file: str = "pyproject.toml"
 
 
 @dataclass

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -8,10 +8,9 @@ Example configuration showing all available sections and their default values:
 
 .. code-block:: toml
 
-   [project]
-   package = ""
-   public_roots = ["."]
-   index_file = "pyproject.toml"
+    [project]
+    package = ""
+    public_roots = ["."]
 
    [ignore]
    paths = ["tests/**", "examples/**", "scripts/**"]
@@ -57,10 +56,6 @@ Project
      - list[str]
      - ``["."]``
      - Paths whose contents constitute the public API.
-   * - ``index_file``
-     - str
-     - ``"pyproject.toml"``
-     - File containing project metadata used for version discovery.
 
 Ignore
 ~~~~~~

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,7 +49,7 @@ def test_tomli_fallback(monkeypatch, tmp_path: Path) -> None:
 
     assert config.tomllib is tomli
     cfg = config.load_config(tmp_path / "missing.toml")
-    assert cfg.project.index_file == "pyproject.toml"
+    assert cfg.project.public_roots == ["."]
 
 
 def test_mutating_config_does_not_alter_defaults(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- drop unused `project.index_file` setting and related docs/tests

## Testing
- `ruff check --fix .`
- `isort bumpwright/config.py tests/test_config.py --check-only -v`
- `black bumpwright/config.py tests/test_config.py --check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07610589083228d53f62b51a6fa1a