### PR TITLE
feat(types): centralize bump level type alias

### DIFF
--- a/bumpwright/analysers/cli.py
+++ b/bumpwright/analysers/cli.py
@@ -6,8 +6,9 @@ import ast
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from ..compare import Impact, Severity
+from ..compare import Impact
 from ..config import Config
+from ..types import BumpLevel
 from . import register
 from .utils import iter_py_files_at_ref
 
@@ -197,11 +198,11 @@ def diff_cli(old: dict[str, Command], new: dict[str, Command]) -> list[Impact]:
         op = old[name].options
         np = new[name].options
         for opt in op.keys() - np.keys():
-            severity: Severity = "major" if op[opt] else "minor"
+            severity: BumpLevel = "major" if op[opt] else "minor"
             reason = "Removed required option" if op[opt] else "Removed optional option"
             impacts.append(Impact(severity, name, f"{reason} '{opt}'"))
         for opt in np.keys() - op.keys():
-            severity: Severity = "major" if np[opt] else "minor"
+            severity: BumpLevel = "major" if np[opt] else "minor"
             reason = "Added required option" if np[opt] else "Added optional option"
             impacts.append(Impact(severity, name, f"{reason} '{opt}'"))
         for opt in op.keys() & np.keys():

--- a/bumpwright/compare.py
+++ b/bumpwright/compare.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
-from typing import Literal
 
 from .public_api import FuncSig, Param, PublicAPI
+from .types import BumpLevel
 
 # Severity levels for public API changes
-Severity = Literal["major", "minor", "patch"]
+Severity = BumpLevel
 
 
 @dataclass(frozen=True)

--- a/bumpwright/types.py
+++ b/bumpwright/types.py
@@ -1,0 +1,8 @@
+"""Common type aliases for bumpwright."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+BumpLevel = Literal["major", "minor", "patch"]
+"""Semantic version bump levels."""

--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -9,7 +9,8 @@ from fnmatch import fnmatch
 from functools import lru_cache
 from glob import glob
 from pathlib import Path
-from typing import Literal
+
+from .types import BumpLevel
 
 try:  # pragma: no cover - needed for linting when dependency missing
     from packaging.version import Version
@@ -34,11 +35,11 @@ class VersionChange:
 
     old: str
     new: str
-    level: Literal["major", "minor", "patch"]
+    level: BumpLevel
     files: list[Path] = field(default_factory=list)
 
 
-def bump_string(v: str, level: Literal["major", "minor", "patch"]) -> str:
+def bump_string(v: str, level: BumpLevel) -> str:
     """Increment a semantic version string by ``level``.
 
     Args:
@@ -136,7 +137,7 @@ def write_project_version(
 
 
 def apply_bump(
-    level: Literal["major", "minor", "patch"],
+    level: BumpLevel,
     pyproject_path: str | Path = "pyproject.toml",
     dry_run: bool = False,
     paths: Iterable[str] | None = None,

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,16 +1,11 @@
 """Tests for public API comparison helpers."""
 
-from bumpwright.compare import (
-    Impact,
-    Severity,
-    compare_funcs,
-    decide_bump,
-    diff_public_api,
-)
+from bumpwright.compare import Impact, compare_funcs, decide_bump, diff_public_api
 from bumpwright.public_api import FuncSig, Param
+from bumpwright.types import BumpLevel
 
-MAJOR: Severity = "major"
-MINOR: Severity = "minor"
+MAJOR: BumpLevel = "major"
+MINOR: BumpLevel = "minor"
 CONFIDENCE_HALF = 0.5
 
 


### PR DESCRIPTION
## Summary
- add shared `BumpLevel` Literal alias
- refactor modules to import the shared alias
- update tests for the new type alias

## Testing
- `ruff check bumpwright/types.py bumpwright/compare.py bumpwright/versioning.py bumpwright/analysers/cli.py tests/test_compare.py`
- `isort bumpwright/types.py bumpwright/compare.py bumpwright/versioning.py bumpwright/analysers/cli.py tests/test_compare.py`
- `black bumpwright/types.py bumpwright/compare.py bumpwright/versioning.py bumpwright/analysers/cli.py tests/test_compare.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0778f6c108322b8f3c4e80bfbddfc