### PR TITLE
refactor(analysers): centralize constant string checks

### DIFF
--- a/bumpwright/analysers/cli.py
+++ b/bumpwright/analysers/cli.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ..compare import Impact, Severity
 from ..config import Config
 from . import register
-from .utils import iter_py_files_at_ref
+from .utils import _is_const_str, iter_py_files_at_ref
 
 
 @dataclass(frozen=True)
@@ -18,19 +18,6 @@ class Command:
 
     name: str
     options: dict[str, bool]  # True if required
-
-
-def _is_str(node: ast.AST) -> bool:
-    """Return whether ``node`` is a constant string.
-
-    Args:
-        node: AST node to examine.
-
-    Returns:
-        ``True`` if the node represents a string literal.
-    """
-
-    return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
 def _extract_click(node: ast.FunctionDef) -> Command | None:
@@ -58,7 +45,7 @@ def _extract_click(node: ast.FunctionDef) -> Command | None:
             ):
                 is_click = True
                 for kw in deco.keywords:
-                    if kw.arg == "name" and _is_str(kw.value):
+                    if kw.arg == "name" and _is_const_str(kw.value):
                         cmd_name = kw.value.value  # type: ignore[assignment]
             elif (
                 isinstance(attr.value, ast.Name)
@@ -68,7 +55,7 @@ def _extract_click(node: ast.FunctionDef) -> Command | None:
                 name: str | None = None
                 required = False
                 for arg in deco.args:
-                    if _is_str(arg) and arg.value.startswith("--"):
+                    if _is_const_str(arg) and arg.value.startswith("--"):
                         name = arg.value
                         break
                 for kw in deco.keywords:
@@ -81,7 +68,7 @@ def _extract_click(node: ast.FunctionDef) -> Command | None:
                 and attr.value.id == "click"
                 and attr.attr == "argument"
             ):
-                if deco.args and _is_str(deco.args[0]):
+                if deco.args and _is_const_str(deco.args[0]):
                     name = deco.args[0].value  # type: ignore[assignment]
                     required = True
                     for kw in deco.keywords:
@@ -118,7 +105,7 @@ def _extract_argparse(tree: ast.AST) -> dict[str, Command]:
                 if (
                     attr.attr == "add_parser"
                     and node.value.args
-                    and _is_str(node.value.args[0])
+                    and _is_const_str(node.value.args[0])
                 ):
                     cmd_name = node.value.args[0].value  # type: ignore[assignment]
                     for target in node.targets:
@@ -136,7 +123,7 @@ def _extract_argparse(tree: ast.AST) -> dict[str, Command]:
                 name: str | None = None
                 required = False
                 for arg in node.args:
-                    if _is_str(arg):
+                    if _is_const_str(arg):
                         if arg.value.startswith("--"):
                             if name is None or not name.startswith("--"):
                                 name = arg.value

--- a/bumpwright/analysers/utils.py
+++ b/bumpwright/analysers/utils.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Iterable, Iterator
 
 from ..gitutils import list_py_files_at_ref, read_file_at_ref
+
+
+def _is_const_str(node: ast.AST) -> bool:
+    """Return whether ``node`` is an ``ast.Constant`` string.
+
+    Args:
+        node: AST node to inspect.
+
+    Returns:
+        ``True`` if ``node`` represents a constant string literal.
+    """
+
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
 def iter_py_files_at_ref(

--- a/bumpwright/analysers/web_routes.py
+++ b/bumpwright/analysers/web_routes.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ..compare import Impact
 from ..config import Config
 from . import register
-from .utils import iter_py_files_at_ref
+from .utils import _is_const_str, iter_py_files_at_ref
 
 HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
 
@@ -21,19 +21,6 @@ class Route:
     path: str
     method: str
     params: dict[str, bool]  # True if required
-
-
-def _is_const_str(node: ast.AST) -> bool:
-    """Return whether ``node`` is a constant string.
-
-    Args:
-        node: AST node to inspect.
-
-    Returns:
-        ``True`` if ``node`` represents a string literal.
-    """
-
-    return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
 def _extract_params(args: ast.arguments) -> dict[str, bool]:

--- a/tests/test_analysers_utils.py
+++ b/tests/test_analysers_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
+
 from bumpwright import gitutils
-from bumpwright.analysers.utils import iter_py_files_at_ref
+from bumpwright.analysers.utils import _is_const_str, iter_py_files_at_ref
 
 
 def test_iter_py_files_at_ref(tmp_path):
@@ -23,3 +25,10 @@ def test_iter_py_files_at_ref(tmp_path):
 
     files = dict(iter_py_files_at_ref("HEAD", ["pkg"], ["pkg/mod.py"], str(repo)))
     assert set(files) == {"pkg/__init__.py"}
+
+
+def test_is_const_str() -> None:
+    const_node = ast.parse("'foo'").body[0].value  # type: ignore[assignment]
+    other_node = ast.parse("1").body[0].value  # type: ignore[assignment]
+    assert _is_const_str(const_node)
+    assert not _is_const_str(other_node)


### PR DESCRIPTION
## Summary
- add shared `_is_const_str` helper
- use `_is_const_str` in CLI and web route analysers
- test constant string detection

## Testing
- `ruff check bumpwright/analysers/utils.py bumpwright/analysers/cli.py bumpwright/analysers/web_routes.py tests/test_analysers_utils.py`
- `black bumpwright/analysers/utils.py bumpwright/analysers/cli.py bumpwright/analysers/web_routes.py tests/test_analysers_utils.py`
- `isort bumpwright/analysers/utils.py bumpwright/analysers/cli.py bumpwright/analysers/web_routes.py tests/test_analysers_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a077952a34832294a449077e5722ac