### PR TITLE
feat(changelog): add configurable Jinja template

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ paths = ["migrations"]
 
 [changelog]
 path = ""
+template = ""
 
 [version]
 paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]
@@ -179,6 +180,8 @@ aspect of bumpwright:
 - **[analysers]** – toggles built-in or plugin analysers.
 - **migrations** – directories containing Alembic migration scripts.
 - **changelog** – default changelog file used with ``--changelog``.
+  ``template`` selects a custom Jinja2 template (leave empty for the built-in
+  version).
 - **version** – files where version strings are read and updated.
 
 See ``docs/configuration.rst`` for in-depth descriptions and additional

--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -150,6 +150,10 @@ def get_parser() -> argparse.ArgumentParser:
         const="-",
         help="Append release notes to FILE or stdout when no path is given.",
     )
+    p_bump.add_argument(
+        "--changelog-template",
+        help="Jinja2 template file for changelog entries; defaults to built-in template.",
+    )
     p_bump.set_defaults(func=bump_command)
     return parser
 

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -16,7 +16,7 @@ _DEFAULTS = {
     "rules": {"return_type_change": "minor"},  # or "major"
     "analysers": {"cli": False},
     "migrations": {"paths": ["migrations"]},
-    "changelog": {"path": ""},
+    "changelog": {"path": "", "template": ""},
     "version": {
         "paths": [
             "pyproject.toml",
@@ -85,9 +85,12 @@ class Changelog:
 
     Attributes:
         path: Default changelog file path. Empty string disables changelog generation.
+        template: Jinja2 template file for changelog entries. Empty string selects
+            the built-in template.
     """
 
     path: str = ""
+    template: str = ""
 
 
 @dataclass
@@ -121,7 +124,7 @@ class Config:
         rules: Rules controlling version bumps.
         ignore: Paths to exclude when scanning.
         analysers: Optional analyser plugin settings.
-        changelog: Default changelog file location.
+        changelog: Changelog file path and template defaults.
         version: Locations containing version strings.
     """
 

--- a/bumpwright/templates/changelog.md.j2
+++ b/bumpwright/templates/changelog.md.j2
@@ -1,0 +1,4 @@
+## [v{{ version }}] - {{ date }}
+{% for c in commits %}- {% if c.link %}[{{ c.sha }}]({{ c.link }}){% else %}{{ c.sha }}{% endif %} {{ c.subject }}
+{% endfor %}
+

--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
 """Click wrappers for documenting the :mod:`bumpwright` CLI."""
 
+from __future__ import annotations
+
 import argparse
-
 import click
-
 from bumpwright.cli.bump import bump_command
 from bumpwright.cli.init import init_command
 
@@ -102,6 +100,11 @@ def init(args: argparse.Namespace) -> int:
     "--changelog",
     type=str,
     help="Append release notes to FILE or stdout when no path is given.",
+)
+@click.option(
+    "--changelog-template",
+    type=str,
+    help=("Jinja2 template file for changelog entries; defaults to built-in template."),
 )
 @click.pass_obj
 def bump(args: argparse.Namespace, **kwargs: object) -> int:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,6 +27,7 @@ Example configuration showing all available sections and their default values:
 
    [changelog]
    path = ""
+   template = ""
 
    [version]
    paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]
@@ -161,8 +162,13 @@ Changelog
    * - ``path``
      - str
      - ``""``
-     - Default file appended when running ``bumpwright bump`` with
-       ``--changelog`` omitted. Empty string means no default file.
+     - Default file appended when running ``bumpwright bump`` with ``--changelog``
+       omitted. Empty string means no default file.
+   * - ``template``
+     - str
+     - ``""``
+     - Jinja2 template file for changelog entries. Empty string selects the
+       built-in template.
 
 All sections and keys are optional; unspecified values fall back to the
 defaults shown above.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,6 +126,10 @@ assignment. These locations can be customised via the ``[version]`` section in
     When ``FILE`` is omitted or set to ``-``, the changelog entry is printed to
     standard output. If the option is omitted, no changelog entry is produced.
 
+``--changelog-template PATH``
+    Jinja2 template file used when rendering changelog entries. Defaults to the
+    built-in template.
+
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to
     ``pyproject.toml``.
@@ -187,6 +191,16 @@ Entries follow a simple Markdown structure:
 Each entry begins with a version heading and date, followed by a list of commit
 shas and subjects since the previous release.
 
+Templates receive the following variables:
+
+``version``
+    The new version string.
+``date``
+    Current date in ISO format.
+``commits``
+    List of mappings with ``sha``, ``subject``, and optional ``link`` keys for
+    commits since the previous release.
+
 Projects can set a default changelog path in ``bumpwright.toml`` so the
 ``bump`` command writes to that location when ``--changelog`` is omitted:
 
@@ -194,10 +208,12 @@ Projects can set a default changelog path in ``bumpwright.toml`` so the
 
    [changelog]
    path = "CHANGELOG.md"
+   template = "changelog.j2"
 
 With this configuration, running ``bumpwright bump`` automatically appends the
-release notes to ``CHANGELOG.md``. To print to stdout instead, invoke
-``bumpwright bump --changelog`` (or pass ``--changelog -`` for clarity).
+release notes to ``CHANGELOG.md`` using ``changelog.j2``. To print to stdout
+instead, invoke ``bumpwright bump --changelog`` (or pass ``--changelog -`` for
+clarity).
 
 To preview changes without touching the filesystem, combine ``--dry-run`` with
 JSON output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "tomlkit>=0.13.2",
   "packaging>=24.0",
   "tomli>=1.0.0",
+  "jinja2>=3.1",
 ]
 
 classifiers = [
@@ -73,6 +74,9 @@ ignore = [
 
 [tool.pytest.ini_options]
 addopts = "-q"
+
+[tool.setuptools.package-data]
+"bumpwright" = ["templates/*.j2"]
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -155,3 +155,72 @@ def test_changelog_links_repo_url(tmp_path: Path) -> None:
     content = (repo / "CHANGELOG.md").read_text()
     expected = f"- [{sha}](https://example.com/repo/commit/{sha}) feat: change"
     assert expected in content
+
+
+def test_changelog_custom_template_cli(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    (repo / "tpl.j2").write_text("VERSION={{ version }}\n", encoding="utf-8")
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(["git", "commit", "-am", "feat: change"], repo)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+            "--changelog",
+            "CHANGELOG.md",
+            "--changelog-template",
+            "tpl.j2",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert (repo / "CHANGELOG.md").read_text() == "VERSION=0.1.1\n"
+
+
+def test_changelog_custom_template_config(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    tpl = repo / "tpl.j2"
+    tpl.write_text("Built {{ version }}\n", encoding="utf-8")
+    (repo / "bumpwright.toml").write_text(
+        "[project]\npublic_roots=['pkg']\n[changelog]\npath='CHANGELOG.md'\ntemplate='tpl.j2'\n",
+        encoding="utf-8",
+    )
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(["git", "commit", "-am", "feat: change"], repo)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert (repo / "CHANGELOG.md").read_text() == "Built 0.1.1\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,19 +23,21 @@ def test_load_config_defaults_analysers(tmp_path: Path) -> None:
 
 def test_load_config_changelog(tmp_path: Path) -> None:
     cfg_file = tmp_path / "bumpwright.toml"
-    cfg_file.write_text("[changelog]\npath='NEWS.md'\n")
+    cfg_file.write_text("[changelog]\npath='NEWS.md'\ntemplate='tmpl.j2'\n")
     cfg = load_config(cfg_file)
     assert cfg.changelog.path == "NEWS.md"
+    assert cfg.changelog.template == "tmpl.j2"
 
 
 def test_load_config_changelog_default(tmp_path: Path) -> None:
     cfg = load_config(tmp_path / "missing.toml")
     assert cfg.changelog.path == ""
+    assert cfg.changelog.template == ""
 
 
 def test_tomli_fallback(monkeypatch, tmp_path: Path) -> None:
     """Ensure ``tomli`` is used when ``tomllib`` is unavailable."""
-    import bumpwright.config as config
+    from bumpwright import config  # noqa: PLC0415
 
     original_import = builtins.__import__
 
@@ -58,7 +60,7 @@ def test_mutating_config_does_not_alter_defaults(tmp_path: Path) -> None:
     cfg = load_config(tmp_path / "missing.toml")
     cfg.project.public_roots.append("src")
 
-    import bumpwright.config as config_module
+    import bumpwright.config as config_module  # noqa: PLC0415
 
     fresh = load_config(tmp_path / "missing.toml")
     assert config_module._DEFAULTS["project"]["public_roots"] == ["."]


### PR DESCRIPTION
## Summary
- allow changelog entries to render via Jinja2 templates
- expose `--changelog-template` CLI flag and config option
- document available changelog template variables

## Testing
- `python -m isort README.md bumpwright/cli/__init__.py bumpwright/cli/bump.py bumpwright/config.py docs/_bumpwright_click.py docs/configuration.rst docs/usage.rst pyproject.toml tests/test_cli_changelog.py tests/test_config.py`
- `python -m black bumpwright/cli/__init__.py bumpwright/cli/bump.py bumpwright/config.py docs/_bumpwright_click.py tests/test_cli_changelog.py tests/test_config.py`
- `ruff check --fix bumpwright/cli/__init__.py bumpwright/cli/bump.py bumpwright/config.py docs/_bumpwright_click.py tests/test_cli_changelog.py tests/test_config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0863a736883228e0259f47b9f4e73