### PR TITLE
fix(versioning): skip unchanged files in version replacement

### DIFF
--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -5,6 +5,7 @@ from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
 from bumpwright.versioning import (
+    _replace_version,
     _resolve_files,
     _resolve_files_cached,
     apply_bump,
@@ -62,9 +63,7 @@ def pyproject_malformed(tmp_path: Path) -> Path:
         ("pyproject_malformed", ParseError),
     ],
 )
-def test_read_project_version_errors(
-    path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest
-) -> None:
+def test_read_project_version_errors(path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest) -> None:
     """Validate ``read_project_version`` error handling for bad inputs."""
 
     path = request.getfixturevalue(path_fixture)
@@ -127,6 +126,26 @@ def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
     assert init not in out.files
 
 
+def test_apply_bump_skips_files_without_version(tmp_path: Path) -> None:
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": "0.1.0"}}))
+    extra = tmp_path / "extra.py"
+    extra.write_text("print('no version here')", encoding="utf-8")
+
+    out = apply_bump("patch", py, paths=[str(extra)], ignore=[])
+
+    assert extra not in out.files
+    assert extra.read_text(encoding="utf-8") == "print('no version here')"
+
+
+def test_replace_version_returns_false_when_unmodified(tmp_path: Path) -> None:
+    target = tmp_path / "module.py"
+    target.write_text("print('hello')", encoding="utf-8")
+
+    assert not _replace_version(target, "0.1.0", "0.2.0")
+    assert target.read_text(encoding="utf-8") == "print('hello')"
+
+
 def test_resolve_files_nested_dirs_sorted(tmp_path: Path) -> None:
     """Resolve nested patterns and ensure results are deterministically ordered."""
 
@@ -178,9 +197,7 @@ def test_resolve_files_absolute_paths_and_ignore_patterns(tmp_path: Path) -> Non
     assert out == expected
 
 
-def test_resolve_files_uses_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_files_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Ensure repeated resolution reuses cached results."""
 
     (tmp_path / "a.txt").write_text("1", encoding="utf-8")
@@ -199,9 +216,7 @@ def test_resolve_files_uses_cache(
     assert calls["count"] == 1
 
 
-def test_apply_bump_clears_resolve_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_apply_bump_clears_resolve_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Verify custom patterns trigger cache invalidation."""
 
     py = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Summary
- avoid writing version files when no substitutions are made
- report only files that actually changed
- test that files without version strings remain untouched

## Testing
- `isort bumpwright/versioning.py tests/test_versioning.py --check-only`
- ⚠️ `black bumpwright/versioning.py tests/test_versioning.py` *(hung in environment)*
- `ruff check bumpwright/versioning.py tests/test_versioning.py --fix`
- `ruff format bumpwright/versioning.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0885f4464832297db20a1bc8ee2ea