### PR TITLE
feat(config): add default version ignore patterns

### DIFF
--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -26,7 +26,16 @@ _DEFAULTS = {
             "**/version.py",
             "**/_version.py",
         ],
-        "ignore": [],
+        "ignore": [
+            "build/**",
+            "dist/**",
+            "*.egg-info/**",
+            ".eggs/**",
+            ".venv/**",
+            "venv/**",
+            ".env/**",
+            "**/__pycache__/**",
+        ],
     },
 }
 
@@ -112,7 +121,18 @@ class VersionFiles:
             "**/_version.py",
         ]
     )
-    ignore: list[str] = field(default_factory=list)
+    ignore: list[str] = field(
+        default_factory=lambda: [
+            "build/**",
+            "dist/**",
+            "*.egg-info/**",
+            ".eggs/**",
+            ".venv/**",
+            "venv/**",
+            ".env/**",
+            "**/__pycache__/**",
+        ]
+    )
 
 
 @dataclass
@@ -164,9 +184,16 @@ def load_config(path: str | Path = "bumpwright.toml") -> Config:
     """
     p = Path(path)
     if not p.exists():
-        d = _merge_defaults({})
+        raw: dict = {}
     else:
-        d = _merge_defaults(tomllib.loads(p.read_text(encoding="utf-8")))
+        raw = tomllib.loads(p.read_text(encoding="utf-8"))
+    user_ignore = raw.get("version", {}).get("ignore")
+    if user_ignore:
+        raw.setdefault("version", {})["ignore"] = [
+            *_DEFAULTS["version"]["ignore"],
+            *user_ignore,
+        ]
+    d = _merge_defaults(raw)
     proj = Project(**d["project"])
     rules = Rules(**d["rules"])
     ign = Ignore(**d["ignore"])

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -143,7 +143,7 @@ Controls where version strings are read and updated.
      - Glob patterns scanned for version declarations.
    * - ``ignore``
      - list[str]
-     - ``[]``
+     - ``["build/**", "dist/**", "*.egg-info/**", ".eggs/**", ".venv/**", "venv/**", ".env/**", "**/__pycache__/**"]``
      - Glob patterns excluded from version replacement.
 
 Command-line options ``--version-path`` and ``--version-ignore`` extend these

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,9 +91,12 @@ Because this mode only inspects commits, there is no effect on the filesystem.
 Update version information in ``pyproject.toml`` and other files.
 By default, ``bumpwright`` also searches ``setup.py``, ``setup.cfg`` and any
 ``__init__.py``, ``version.py`` or ``_version.py`` files for a version
-assignment. These locations can be customised via the ``[version]`` section in
-``bumpwright.toml`` or augmented with ``--version-path`` and
-``--version-ignore`` to add or exclude patterns.
+assignment. Files inside common build artifacts and virtual environments are
+ignored by default (``build/**``, ``dist/**``, ``*.egg-info/**``, ``.eggs/**``,
+``.venv/**``, ``venv/**``, ``.env/**`` and ``**/__pycache__/**``). These
+locations can be customised via the ``[version]`` section in ``bumpwright.toml``
+or augmented with ``--version-path`` and ``--version-ignore`` to add or exclude
+patterns.
 
 **Arguments**
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,3 +65,23 @@ def test_mutating_config_does_not_alter_defaults(tmp_path: Path) -> None:
     fresh = load_config(tmp_path / "missing.toml")
     assert config_module._DEFAULTS["project"]["public_roots"] == ["."]
     assert fresh.project.public_roots == ["."]
+
+
+def test_version_ignore_defaults_extend(tmp_path: Path) -> None:
+    """Custom version ignores extend the built-in defaults."""
+
+    cfg_file = tmp_path / "bumpwright.toml"
+    cfg_file.write_text("[version]\nignore=['custom/**']\n")
+    cfg = load_config(cfg_file)
+    assert "custom/**" in cfg.version.ignore
+    defaults = {
+        "build/**",
+        "dist/**",
+        "*.egg-info/**",
+        ".eggs/**",
+        ".venv/**",
+        "venv/**",
+        ".env/**",
+        "**/__pycache__/**",
+    }
+    assert defaults.issubset(set(cfg.version.ignore))

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,6 +4,7 @@ import pytest
 from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
+from bumpwright.config import load_config
 from bumpwright.versioning import (
     _resolve_files,
     _resolve_files_cached,
@@ -125,6 +126,44 @@ def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
     out = apply_bump("minor", py, ignore=[str(init)])
     assert "__version__ = '1.0.0'" in init.read_text(encoding="utf-8")
     assert init not in out.files
+
+
+@pytest.mark.parametrize(
+    "ignore_dir,file_name",
+    [
+        ("build/pkg", "__init__.py"),
+        ("dist/pkg", "__init__.py"),
+        ("project.egg-info", "__init__.py"),
+        (".eggs/pkg", "__init__.py"),
+        (".venv/pkg", "__init__.py"),
+        ("venv/pkg", "__init__.py"),
+        (".env/pkg", "__init__.py"),
+        ("pkg/__pycache__", "version.py"),
+    ],
+)
+def test_default_version_ignore_patterns(
+    tmp_path: Path, ignore_dir: str, file_name: str
+) -> None:
+    """Version files in ignored directories are skipped by default."""
+
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": "1.0.0"}}))
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    init = pkg / "__init__.py"
+    init.write_text("__version__ = '1.0.0'", encoding="utf-8")
+
+    ignore_path = tmp_path / ignore_dir
+    ignore_path.mkdir(parents=True)
+    ignored_file = ignore_path / file_name
+    ignored_file.write_text("__version__ = '1.0.0'", encoding="utf-8")
+
+    cfg = load_config(tmp_path / "bumpwright.toml")
+    out = apply_bump("minor", py, paths=cfg.version.paths, ignore=cfg.version.ignore)
+
+    assert "__version__ = '1.1.0'" in init.read_text(encoding="utf-8")
+    assert "__version__ = '1.0.0'" in ignored_file.read_text(encoding="utf-8")
+    assert ignored_file not in out.files
 
 
 def test_resolve_files_nested_dirs_sorted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add default ignore patterns for version file scanning
- document default version ignores in configuration and usage docs
- test default ignores and config merging

## Testing
- `ruff check --fix bumpwright/config.py tests/test_config.py tests/test_versioning.py`
- `black bumpwright/config.py tests/test_config.py tests/test_versioning.py`
- `isort bumpwright/config.py tests/test_config.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0886a25c48322a90dbb1fcc2e83a6