### PR TITLE
feat(cli): report skipped files during version bump

### DIFF
--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -163,6 +163,7 @@ def _display_result(
                     "confidence": decision.confidence,
                     "reasons": decision.reasons,
                     "files": [str(p) for p in vc.files],
+                    "skipped": [str(p) for p in vc.skipped],
                 },
                 indent=2,
             )
@@ -170,9 +171,13 @@ def _display_result(
     elif args.format == "md":
         print(f"Bumped version: `{vc.old}` -> `{vc.new}` ({vc.level})")
         print("Updated files:\n" + "\n".join(f"- `{p}`" for p in vc.files))
+        if vc.skipped:
+            print("Skipped files:\n" + "\n".join(f"- `{p}`" for p in vc.skipped))
     else:
         print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
         print("Updated files: " + ", ".join(str(p) for p in vc.files))
+        if vc.skipped:
+            print("Skipped files: " + ", ".join(str(p) for p in vc.skipped))
 
 
 def _write_changelog(args: argparse.Namespace, changelog: str | None) -> None:

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -39,6 +39,22 @@ def test_display_result_json(capsys):
     _display_result(args, vc, dec)
     data = json.loads(capsys.readouterr().out)
     assert data["new_version"] == "0.2.0"
+    assert data["skipped"] == []
+
+
+def test_display_result_text_skipped(capsys):
+    args = argparse.Namespace(format="text")
+    vc = VersionChange(
+        "0.1.0",
+        "0.2.0",
+        "minor",
+        [Path("pyproject.toml")],
+        [Path("extra.py")],
+    )
+    dec = Decision("minor", 1.0, [])
+    _display_result(args, vc, dec)
+    out = capsys.readouterr().out
+    assert "Skipped files: extra.py" in out
 
 
 def test_write_changelog_to_file(tmp_path):


### PR DESCRIPTION
## Summary
- track files skipped during version replacement and expose in CLI output
- test reporting of skipped files and versioning logic

## Testing
- `python -m isort bumpwright/versioning.py bumpwright/cli/bump.py tests/test_cli_bump_helpers.py tests/test_versioning.py`
- `python -m black bumpwright/versioning.py bumpwright/cli/bump.py tests/test_cli_bump_helpers.py tests/test_versioning.py`
- `python -m ruff check bumpwright/versioning.py bumpwright/cli/bump.py tests/test_cli_bump_helpers.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08b52966083228479198aba2712b5