### PR TITLE
docs(analysers): clarify optional analysers are opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Design goals include:
 ## Features
 
 - Static diff of the public API to highlight breaking changes.
-- Pluggable analysers for command-line tools, web routes and database
-  migrations.
+ - Pluggable analysers for command-line tools, web routes and database
+   migrations. These analysers are **opt-in** and disabled by default; enable
+   them explicitly in configuration.
 - Dry-run mode to preview version bumps without touching any files.
 - Output in plain text, Markdown or JSON for easy integration.
 - Optional helpers to update version numbers across common files and tag the release.
@@ -64,12 +65,18 @@ See [docs/quickstart.rst](docs/quickstart.rst) for a step-by-step example.
 - `--enable-analyser` or `--disable-analyser`: toggle analysers
 - See [CLI reference](docs/cli_reference.rst) for details.
 
-1. **Create a configuration file** (``bumpwright.toml``) to customise behaviour:
+1. **Create a configuration file** (``bumpwright.toml``). Analysers are
+   opt-in, so enable the ones you need:
 
    ```toml
+   # bumpwright.toml
    [analysers]
-   cli = true      # enable CLI analysis
-   web_routes = false  # disable route analysis
+   cli = true        # enable CLI analysis
+   web_routes = true # enable web route analysis
+   migrations = true # enable migrations analysis
+
+   [migrations]
+   paths = ["migrations"]
    ```
 
    Command-line flags ``--enable-analyser`` and ``--disable-analyser`` can

--- a/docs/analysers/index.rst
+++ b/docs/analysers/index.rst
@@ -1,17 +1,18 @@
 Additional Analysers
 ====================
 
-Enable optional analysers in ``bumpwright.toml``:
+The CLI, web route and migration analysers are **opt-in** and disabled by
+default. Enable them in ``bumpwright.toml``:
 
 .. code-block:: toml
 
    [analysers]
-   cli = true
-   web_routes = true
-   migrations = true
+   cli = true        # enable CLI analysis
+   web_routes = true # enable web route analysis
+   migrations = true # enable migrations analysis
 
    [migrations]
-   paths = ["migrations"]
+   paths = ["migrations"]  # directories with Alembic scripts
 
 You can also toggle analysers per invocation with the command-line flags
 ``--enable-analyser`` and ``--disable-analyser``.

--- a/tests/test_analysers_opt_in.py
+++ b/tests/test_analysers_opt_in.py
@@ -1,0 +1,17 @@
+"""Integration tests for opt-in analyser behaviour."""
+
+from pathlib import Path
+
+from bumpwright.analysers import load_enabled
+from bumpwright.config import load_config
+
+
+def test_no_analyser_enabled_by_default(tmp_path: Path) -> None:
+    """Verify that analysers are inactive without explicit configuration.
+
+    Args:
+        tmp_path: Temporary directory for an isolated config path.
+    """
+    cfg = load_config(tmp_path / "bumpwright.toml")
+    analysers = load_enabled(cfg)
+    assert analysers == []


### PR DESCRIPTION
## Summary
- document that CLI, web-route, and migration analysers are opt-in
- add config example enabling each analyser
- cover default behaviour with integration test

## Testing
- `isort tests/test_analysers_opt_in.py`
- `black tests/test_analysers_opt_in.py`
- `ruff check tests/test_analysers_opt_in.py --fix`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a08e3a36188322b12f6eade8a1b0b3