### PR TITLE
feat(versioning): support prerelease and build bumps

### DIFF
--- a/bumpwright/types.py
+++ b/bumpwright/types.py
@@ -4,5 +4,5 @@ from __future__ import annotations
 
 from typing import Literal
 
-BumpLevel = Literal["major", "minor", "patch"]
-"""Semantic version bump levels."""
+BumpLevel = Literal["major", "minor", "patch", "pre", "build"]
+"""Semantic version bump levels including prerelease and build identifiers."""

--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -25,7 +25,8 @@ class VersionChange:
     Attributes:
         old: Previous version string.
         new: New version string after bump.
-        level: Bump level applied (``"major"``, ``"minor"``, or ``"patch"``).
+        level: Bump level applied (``"major"``, ``"minor"``, ``"patch"``,
+            ``"pre"``, or ``"build"``).
         files: Files updated with the new version.
     """
 
@@ -100,7 +101,9 @@ def read_project_version(pyproject_path: str | Path = "pyproject.toml") -> str:
         raise KeyError("project.version not found in pyproject.toml") from e
 
 
-def write_project_version(new_version: str, pyproject_path: str | Path = "pyproject.toml") -> None:
+def write_project_version(
+    new_version: str, pyproject_path: str | Path = "pyproject.toml"
+) -> None:
     """Write ``new_version`` to the ``pyproject.toml`` file.
 
     Args:
@@ -211,7 +214,9 @@ def _update_additional_files(
     return changed
 
 
-def _resolve_files(patterns: Iterable[str], ignore: Iterable[str], base_dir: Path) -> list[Path]:
+def _resolve_files(
+    patterns: Iterable[str], ignore: Iterable[str], base_dir: Path
+) -> list[Path]:
     """Expand glob patterns while applying ignore rules relative to ``base_dir``.
 
     Args:
@@ -232,7 +237,9 @@ def _resolve_files(patterns: Iterable[str], ignore: Iterable[str], base_dir: Pat
 
 
 @lru_cache(maxsize=None)
-def _resolve_files_cached(patterns: tuple[str, ...], ignore: tuple[str, ...], base_dir: str) -> tuple[Path, ...]:
+def _resolve_files_cached(
+    patterns: tuple[str, ...], ignore: tuple[str, ...], base_dir: str
+) -> tuple[Path, ...]:
     """Resolve files for caching.
 
     This function performs the actual glob resolution and is wrapped with

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Static public-API diff and heuristics to suggest semantic version bumps.
    installation
    quickstart
    usage
+   versioning
    cli_reference
 
 .. toctree::

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,0 +1,31 @@
+Versioning
+==========
+
+``bumpwright`` provides multiple versioning schemes and preserves prerelease
+and build metadata when bumping versions.
+
+SemVer
+------
+
+The :class:`~bumpwright.version_schemes.SemverScheme` tracks prerelease and
+build identifiers. Both parts can be incremented independently:
+
+.. code-block:: python
+
+   from bumpwright.versioning import bump_string
+   bump_string("1.0.0-alpha.1", "pre", scheme="semver")  # 1.0.0-alpha.2
+   bump_string("1.0.0+build.1", "build", scheme="semver")  # 1.0.0+build.2
+
+PEP 440
+-------
+
+The :class:`~bumpwright.version_schemes.Pep440Scheme` also manages pre-release
+segments (``a1``, ``rc1``) and local version identifiers:
+
+.. code-block:: python
+
+   bump_string("1.0.0rc1", "pre", scheme="pep440")    # 1.0.0rc2
+   bump_string("1.0.0+local.1", "build", scheme="pep440")  # 1.0.0+local.2
+
+Use these additional bump levels to manage prerelease and build metadata without
+altering the main release components.


### PR DESCRIPTION
## Summary
- handle prerelease and build/local segments in SemVer and PEP 440 schemes
- document version scheme behaviour and add tests for new bump levels

## Testing
- `ruff check bumpwright/version_schemes.py bumpwright/versioning.py bumpwright/types.py tests/test_versioning.py`
- `black bumpwright/version_schemes.py bumpwright/versioning.py bumpwright/types.py tests/test_versioning.py`
- `isort --profile black bumpwright/types.py bumpwright/version_schemes.py bumpwright/versioning.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08e3ac73083228f6513abe267f3e7