### PR TITLE
chore(ci): add auto version bump workflow

### DIFF
--- a/.github/workflows/bumpwright-auto-bump.yml
+++ b/.github/workflows/bumpwright-auto-bump.yml
@@ -1,0 +1,24 @@
+name: bumpwright auto bump
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install bumpwright
+        run: pip install bumpwright
+      - name: Bump version and update changelog
+        run: |
+          bumpwright bump --decide --pyproject pyproject.toml --changelog CHANGELOG.md --commit --tag
+      - name: Push changes
+        run: git push origin HEAD --follow-tags


### PR DESCRIPTION
## Summary
- add workflow to bump version and changelog on push to master

## Testing
- `pre-commit run --files .github/workflows/bumpwright-auto-bump.yml`
- `pytest`

## Labels
- chore

------
https://chatgpt.com/codex/tasks/task_e_68a0967e88a083228360f094a3fb1c7c