### PR TITLE
feat(config): add web_routes and migrations analyser defaults

### DIFF
--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -14,7 +14,7 @@ _DEFAULTS = {
     "project": {"package": "", "public_roots": ["."]},
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
-    "analysers": {"cli": False},
+    "analysers": {"cli": False, "web_routes": False, "migrations": False},
     "migrations": {"paths": ["migrations"]},
     "changelog": {"path": "", "template": ""},
     "version": {
@@ -36,7 +36,6 @@ _DEFAULTS = {
             ".env/**",
             "**/__pycache__/**",
         ],
-
         "scheme": "semver",
     },
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,10 +10,12 @@ from bumpwright.config import load_config
 
 
 def test_load_config_parses_analysers(tmp_path: Path) -> None:
+    """Enable and disable analysers based on config values."""
+
     cfg_file = tmp_path / "bumpwright.toml"
-    cfg_file.write_text("[analysers]\nflask_routes = true\nsqlalchemy = false\n")
+    cfg_file.write_text("[analysers]\nweb_routes = true\nmigrations = false\n")
     cfg = load_config(cfg_file)
-    assert cfg.analysers.enabled == {"flask_routes"}
+    assert cfg.analysers.enabled == {"web_routes"}
 
 
 def test_load_config_defaults_analysers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend default analyser configuration with web_routes and migrations
- test config parsing with new analyser defaults

## Testing
- `pre-commit run --files bumpwright/config.py tests/test_config.py`
- `pytest`

## Labels
- feat

------
https://chatgpt.com/codex/tasks/task_e_68a098f0b088832298f9835e648d142b