### PR TITLE
docs(cli): support optional changelog argument

### DIFF
--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -119,6 +119,11 @@ def init(args: argparse.Namespace) -> int:
 @click.option(
     "--changelog",
     type=str,
+    flag_value="-",
+    default=None,
+    nargs=1,
+    is_flag=False,
+    metavar="[FILE]",
     help="Append release notes to FILE or stdout when no path is given.",
 )
 @click.option(


### PR DESCRIPTION
## Summary
- make `--changelog` option optional in Click CLI docs to mirror argparse behavior
- regenerate CLI documentation for the updated option

## Testing
- `pre-commit run --files docs/_bumpwright_click.py`
- `pytest`
- `sphinx-build -b html docs docs/build`


------
https://chatgpt.com/codex/tasks/task_e_68a098fa1dac8322a8495ff3c0767532