### PR TITLE
docs(configuration): document migrations analyser

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,6 +21,7 @@ Example configuration showing all available sections and their default values:
     [analysers]
     cli = false
     web_routes = false
+    migrations = false
 
     [migrations]
     paths = ["migrations"]
@@ -112,6 +113,9 @@ temporarily override these settings. Built-in analysers include:
    * - ``web_routes``
      - Tracks additions or removals of web routes in frameworks such as
        Flask or FastAPI.
+     - ``false``
+   * - ``migrations``
+     - Scans Alembic migrations for schema impacts.
      - ``false``
 
 Migrations


### PR DESCRIPTION
## Summary
- document `migrations` analyser in configuration examples

## Testing
- `pre-commit run --files docs/configuration.rst`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a09c2d15448322862065fd3054ebcf