### PR TITLE
docs(readme): update example output to show suggested bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ aborts if uncommitted changes are detected.
 
    ```console
    $ bumpwright bump --decide --base origin/main --head HEAD --format text
-   bumpwright suggests: minor
+   Suggested bump: minor
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```
 
    ```console
    $ bumpwright bump --decide --base origin/main --head HEAD --format md
-   **bumpwright** suggests: `minor`
+   **Suggested bump:** `minor`
 
 
    - [MINOR] cli.new_command: added CLI entry 'greet'


### PR DESCRIPTION
## Summary
- update README example output to display `Suggested bump: minor`
- retain accurate bullet list of impacts

## Testing
- `pre-commit run --files README.md`
- `pytest`

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_68a09c3efab88322b3adee84c57867e8