### PR TITLE
docs(quickstart): reflect CLI suggestion and impacts

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -60,12 +60,12 @@ Start with a tiny example project to see **bumpwright** in action.
 
    .. code-block:: text
 
-      level  confidence
-      -----  -----------
-      minor  1.00
+      Suggested bump: minor
+      - [MINOR] demo:greet: Added public symbol
 
    ``bumpwright`` inspects commits since the baseline and suggests the next
-   semantic version.
+   semantic version. The lines following the suggestion list the impacts that
+   informed it.
 
 Flow
 ----


### PR DESCRIPTION
## Summary
- update quickstart example to show `Suggested bump` output and impact list
- note that impacts are listed after the suggestion for clarity

## Testing
- `ruff check .`
- `black --check docs/quickstart.rst` *(fails: Cannot parse docs/quickstart.rst)*
- `isort --check-only .`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a09c3574548322b22d6c883e593155