### PR TITLE
fix(versioning): deduplicate resolved file paths

### DIFF
--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -103,7 +103,9 @@ def read_project_version(pyproject_path: str | Path = "pyproject.toml") -> str:
         raise KeyError("project.version not found in pyproject.toml") from e
 
 
-def write_project_version(new_version: str, pyproject_path: str | Path = "pyproject.toml") -> None:
+def write_project_version(
+    new_version: str, pyproject_path: str | Path = "pyproject.toml"
+) -> None:
     """Write ``new_version`` to the ``pyproject.toml`` file.
 
     Args:
@@ -218,7 +220,9 @@ def _update_additional_files(
     return changed, skipped
 
 
-def _resolve_files(patterns: Iterable[str], ignore: Iterable[str], base_dir: Path) -> list[Path]:
+def _resolve_files(
+    patterns: Iterable[str], ignore: Iterable[str], base_dir: Path
+) -> list[Path]:
     """Expand glob patterns while applying ignore rules relative to ``base_dir``.
 
     Args:
@@ -239,7 +243,9 @@ def _resolve_files(patterns: Iterable[str], ignore: Iterable[str], base_dir: Pat
 
 
 @lru_cache(maxsize=None)
-def _resolve_files_cached(patterns: tuple[str, ...], ignore: tuple[str, ...], base_dir: str) -> tuple[Path, ...]:
+def _resolve_files_cached(
+    patterns: tuple[str, ...], ignore: tuple[str, ...], base_dir: str
+) -> tuple[Path, ...]:
     """Resolve files for caching.
 
     This function performs the actual glob resolution and is wrapped with
@@ -251,10 +257,10 @@ def _resolve_files_cached(patterns: tuple[str, ...], ignore: tuple[str, ...], ba
         base_dir: Directory relative to which patterns are evaluated.
 
     Returns:
-        Tuple of discovered file paths matching ``patterns`` minus ``ignore``.
+        Tuple of unique file paths matching ``patterns`` minus ``ignore``.
     """
 
-    out: list[Path] = []
+    out: set[Path] = set()
     ignore_list = list(ignore)
     base = Path(base_dir)
     for pat in patterns:
@@ -271,10 +277,9 @@ def _resolve_files_cached(patterns: tuple[str, ...], ignore: tuple[str, ...], ba
                 rel_str = path_str
             if any(fnmatch(path_str, ig) or fnmatch(rel_str, ig) for ig in ignore_list):
                 continue
-            out.append(p)
+            out.add(p)
     # Ensure deterministic ordering for predictable downstream operations.
-    out.sort()
-    return tuple(out)
+    return tuple(sorted(out))
 
 
 def _replace_version(path: Path, old: str, new: str) -> bool:

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -5,10 +5,16 @@ from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
 from bumpwright.config import load_config
-from bumpwright.versioning import (_replace_version, _resolve_files,
-                                   _resolve_files_cached, apply_bump,
-                                   bump_string, find_pyproject,
-                                   read_project_version, write_project_version)
+from bumpwright.versioning import (
+    _replace_version,
+    _resolve_files,
+    _resolve_files_cached,
+    apply_bump,
+    bump_string,
+    find_pyproject,
+    read_project_version,
+    write_project_version,
+)
 
 
 def test_bump_string():
@@ -20,7 +26,10 @@ def test_bump_string():
 def test_bump_string_semver_prerelease_and_build() -> None:
     """SemVer bumps preserve and increment prerelease and build metadata."""
 
-    assert bump_string("1.2.3-alpha.1+build.1", "patch", scheme="semver") == "1.2.4-alpha.1+build.1"
+    assert (
+        bump_string("1.2.3-alpha.1+build.1", "patch", scheme="semver")
+        == "1.2.4-alpha.1+build.1"
+    )
     assert bump_string("1.2.3-alpha.1", "pre", scheme="semver") == "1.2.3-alpha.2"
     assert bump_string("1.2.3+build.1", "build", scheme="semver") == "1.2.3+build.2"
 
@@ -28,7 +37,9 @@ def test_bump_string_semver_prerelease_and_build() -> None:
 def test_bump_string_pep440_pre_and_local() -> None:
     """PEP 440 bumps handle prerelease and local segments."""
 
-    assert bump_string("1.2.3rc1+local.1", "patch", scheme="pep440") == "1.2.4rc1+local.1"
+    assert (
+        bump_string("1.2.3rc1+local.1", "patch", scheme="pep440") == "1.2.4rc1+local.1"
+    )
     assert bump_string("1.2.3a1", "pre", scheme="pep440") == "1.2.3a2"
     assert bump_string("1.2.3+local.1", "build", scheme="pep440") == "1.2.3+local.2"
 
@@ -74,7 +85,9 @@ def pyproject_malformed(tmp_path: Path) -> Path:
         ("pyproject_malformed", ParseError),
     ],
 )
-def test_read_project_version_errors(path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest) -> None:
+def test_read_project_version_errors(
+    path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest
+) -> None:
     """Validate ``read_project_version`` error handling for bad inputs."""
 
     path = request.getfixturevalue(path_fixture)
@@ -154,7 +167,9 @@ def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
         ("pkg/__pycache__", "version.py"),
     ],
 )
-def test_default_version_ignore_patterns(tmp_path: Path, ignore_dir: str, file_name: str) -> None:
+def test_default_version_ignore_patterns(
+    tmp_path: Path, ignore_dir: str, file_name: str
+) -> None:
     """Version files in ignored directories are skipped by default."""
 
     py = tmp_path / "pyproject.toml"
@@ -199,7 +214,9 @@ def test_replace_version_returns_false_when_unmodified(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "print('hello')"
 
 
-def test_apply_bump_respects_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bump_respects_scheme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Use configured version scheme when bumping."""
 
     (tmp_path / "bumpwright.toml").write_text("[version]\nscheme='pep440'\n")
@@ -211,7 +228,9 @@ def test_apply_bump_respects_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert out.skipped == []
 
 
-def test_apply_bump_invalid_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bump_invalid_scheme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Invalid version schemes raise clear errors."""
 
     (tmp_path / "bumpwright.toml").write_text("[version]\nscheme='unknown'\n")
@@ -273,7 +292,23 @@ def test_resolve_files_absolute_paths_and_ignore_patterns(tmp_path: Path) -> Non
     assert out == expected
 
 
-def test_resolve_files_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_resolve_files_overlapping_patterns_deduped(tmp_path: Path) -> None:
+    """Overlapping glob patterns yield unique, sorted results."""
+
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("", encoding="utf-8")
+    b.write_text("", encoding="utf-8")
+
+    patterns = ["*.txt", "a.*", "b.*"]
+    out = _resolve_files(patterns, [], tmp_path)
+
+    assert out == [a, b]
+
+
+def test_resolve_files_uses_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Ensure repeated resolution reuses cached results."""
 
     (tmp_path / "a.txt").write_text("1", encoding="utf-8")
@@ -292,7 +327,9 @@ def test_resolve_files_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert calls["count"] == 1
 
 
-def test_apply_bump_clears_resolve_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_apply_bump_clears_resolve_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Verify custom patterns trigger cache invalidation."""
 
     py = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Summary
- avoid duplicate file processing by caching unique paths
- test overlapping glob patterns only processed once

## Testing
- `isort bumpwright/versioning.py tests/test_versioning.py`
- `black bumpwright/versioning.py tests/test_versioning.py`
- `ruff check bumpwright/versioning.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09c68dc208322be0535e698dd9484