### PR TITLE
feat(versioning): reset prerelease metadata on release bump

### DIFF
--- a/bumpwright/version_schemes.py
+++ b/bumpwright/version_schemes.py
@@ -16,7 +16,9 @@ except ModuleNotFoundError as exc:  # pragma: no cover
 
 MIN_RELEASE_PARTS = 3
 
-_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$")
+_SEMVER_RE = re.compile(
+    r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$"
+)
 
 
 def _bump_segment(segment: str | None, default: str) -> str:
@@ -70,7 +72,8 @@ class SemverScheme:
             level: Bump level to apply.
 
         Returns:
-            The bumped semantic version string.
+            The bumped semantic version string. ``major``, ``minor``, and
+            ``patch`` bumps reset any prerelease or build information.
 
         Raises:
             ValueError: If ``level`` is unknown or ``version`` is invalid.
@@ -83,10 +86,16 @@ class SemverScheme:
         parts = [int(major), int(minor), int(patch)]
         if level == "major":
             parts = [parts[0] + 1, 0, 0]
+            pre = None
+            build = None
         elif level == "minor":
             parts = [parts[0], parts[1] + 1, 0]
+            pre = None
+            build = None
         elif level == "patch":
             parts = [parts[0], parts[1], parts[2] + 1]
+            pre = None
+            build = None
         elif level == "pre":
             pre = _bump_segment(pre, "rc")
         elif level == "build":
@@ -114,7 +123,9 @@ class Pep440Scheme:
             level: Bump level to apply.
 
         Returns:
-            The bumped version string with any epoch preserved.
+            The bumped version string with any epoch preserved. ``major``,
+            ``minor``, and ``patch`` bumps drop prerelease and local
+            components.
 
         Raises:
             ValueError: If ``level`` is unsupported.
@@ -129,10 +140,16 @@ class Pep440Scheme:
             release.append(0)
         if level == "major":
             release = [release[0] + 1, 0, 0]
+            pre = None
+            local = None
         elif level == "minor":
             release = [release[0], release[1] + 1, 0]
+            pre = None
+            local = None
         elif level == "patch":
             release = [release[0], release[1], release[2] + 1]
+            pre = None
+            local = None
         elif level == "pre":
             if pre:
                 pre = (pre[0], pre[1] + 1)

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,31 +1,37 @@
 Versioning
 ==========
 
-``bumpwright`` provides multiple versioning schemes and preserves prerelease
-and build metadata when bumping versions.
+``bumpwright`` provides multiple versioning schemes. Release-level bumps
+(``major``, ``minor``, ``patch``) reset any prerelease or build/local segments.
+Use the dedicated ``pre`` and ``build`` levels to update those segments
+independently.
 
 SemVer
 ------
 
 The :class:`~bumpwright.version_schemes.SemverScheme` tracks prerelease and
-build identifiers. Both parts can be incremented independently:
+build identifiers. Use ``pre`` and ``build`` to manage these segments while
+release bumps clear them:
 
 .. code-block:: python
 
    from bumpwright.versioning import bump_string
    bump_string("1.0.0-alpha.1", "pre", scheme="semver")  # 1.0.0-alpha.2
    bump_string("1.0.0+build.1", "build", scheme="semver")  # 1.0.0+build.2
+   bump_string("1.0.0-alpha.1+build.1", "patch", scheme="semver")  # 1.0.1
 
 PEP 440
 -------
 
 The :class:`~bumpwright.version_schemes.Pep440Scheme` also manages pre-release
-segments (``a1``, ``rc1``) and local version identifiers:
+segments (``a1``, ``rc1``) and local version identifiers. As with SemVer,
+release bumps drop these components:
 
 .. code-block:: python
 
    bump_string("1.0.0rc1", "pre", scheme="pep440")    # 1.0.0rc2
    bump_string("1.0.0+local.1", "build", scheme="pep440")  # 1.0.0+local.2
+   bump_string("1.0.0rc1+local.1", "patch", scheme="pep440")  # 1.0.1
 
-Use these additional bump levels to manage prerelease and build metadata without
-altering the main release components.
+Use these bump levels to manage prerelease and build metadata without altering
+the main release components.

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -5,10 +5,16 @@ from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
 from bumpwright.config import load_config
-from bumpwright.versioning import (_replace_version, _resolve_files,
-                                   _resolve_files_cached, apply_bump,
-                                   bump_string, find_pyproject,
-                                   read_project_version, write_project_version)
+from bumpwright.versioning import (
+    _replace_version,
+    _resolve_files,
+    _resolve_files_cached,
+    apply_bump,
+    bump_string,
+    find_pyproject,
+    read_project_version,
+    write_project_version,
+)
 
 
 def test_bump_string():
@@ -18,17 +24,21 @@ def test_bump_string():
 
 
 def test_bump_string_semver_prerelease_and_build() -> None:
-    """SemVer bumps preserve and increment prerelease and build metadata."""
+    """SemVer release bumps clear prerelease and build metadata."""
 
-    assert bump_string("1.2.3-alpha.1+build.1", "patch", scheme="semver") == "1.2.4-alpha.1+build.1"
+    assert bump_string("1.2.3-alpha.1+build.1", "patch", scheme="semver") == "1.2.4"
+    assert bump_string("1.2.3-alpha.1+build.1", "minor", scheme="semver") == "1.3.0"
+    assert bump_string("1.2.3-alpha.1+build.1", "major", scheme="semver") == "2.0.0"
     assert bump_string("1.2.3-alpha.1", "pre", scheme="semver") == "1.2.3-alpha.2"
     assert bump_string("1.2.3+build.1", "build", scheme="semver") == "1.2.3+build.2"
 
 
 def test_bump_string_pep440_pre_and_local() -> None:
-    """PEP 440 bumps handle prerelease and local segments."""
+    """PEP 440 release bumps remove prerelease and local identifiers."""
 
-    assert bump_string("1.2.3rc1+local.1", "patch", scheme="pep440") == "1.2.4rc1+local.1"
+    assert bump_string("1.2.3rc1+local.1", "patch", scheme="pep440") == "1.2.4"
+    assert bump_string("1.2.3rc1+local.1", "minor", scheme="pep440") == "1.3.0"
+    assert bump_string("1.2.3rc1+local.1", "major", scheme="pep440") == "2.0.0"
     assert bump_string("1.2.3a1", "pre", scheme="pep440") == "1.2.3a2"
     assert bump_string("1.2.3+local.1", "build", scheme="pep440") == "1.2.3+local.2"
 
@@ -74,7 +84,9 @@ def pyproject_malformed(tmp_path: Path) -> Path:
         ("pyproject_malformed", ParseError),
     ],
 )
-def test_read_project_version_errors(path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest) -> None:
+def test_read_project_version_errors(
+    path_fixture: str, exc: type[Exception], request: pytest.FixtureRequest
+) -> None:
     """Validate ``read_project_version`` error handling for bad inputs."""
 
     path = request.getfixturevalue(path_fixture)
@@ -154,7 +166,9 @@ def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
         ("pkg/__pycache__", "version.py"),
     ],
 )
-def test_default_version_ignore_patterns(tmp_path: Path, ignore_dir: str, file_name: str) -> None:
+def test_default_version_ignore_patterns(
+    tmp_path: Path, ignore_dir: str, file_name: str
+) -> None:
     """Version files in ignored directories are skipped by default."""
 
     py = tmp_path / "pyproject.toml"
@@ -199,7 +213,9 @@ def test_replace_version_returns_false_when_unmodified(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "print('hello')"
 
 
-def test_apply_bump_respects_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bump_respects_scheme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Use configured version scheme when bumping."""
 
     (tmp_path / "bumpwright.toml").write_text("[version]\nscheme='pep440'\n")
@@ -211,7 +227,9 @@ def test_apply_bump_respects_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert out.skipped == []
 
 
-def test_apply_bump_invalid_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bump_invalid_scheme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Invalid version schemes raise clear errors."""
 
     (tmp_path / "bumpwright.toml").write_text("[version]\nscheme='unknown'\n")
@@ -273,7 +291,9 @@ def test_resolve_files_absolute_paths_and_ignore_patterns(tmp_path: Path) -> Non
     assert out == expected
 
 
-def test_resolve_files_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_resolve_files_uses_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Ensure repeated resolution reuses cached results."""
 
     (tmp_path / "a.txt").write_text("1", encoding="utf-8")
@@ -292,7 +312,9 @@ def test_resolve_files_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert calls["count"] == 1
 
 
-def test_apply_bump_clears_resolve_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_apply_bump_clears_resolve_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Verify custom patterns trigger cache invalidation."""
 
     py = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Summary
- reset prerelease/build metadata on major, minor, and patch bumps for SemVer and PEP 440 schemes
- document release-bump behaviour for prerelease/local segments
- expand versioning tests for new semantics

## Testing
- `ruff check bumpwright/version_schemes.py tests/test_versioning.py`
- `black bumpwright/version_schemes.py tests/test_versioning.py`
- `isort bumpwright/version_schemes.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09c54ca8c832295805600417f0083