### PR TITLE
refactor(versioning): precompile version replacement regex patterns

### DIFF
--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -19,6 +19,14 @@ from .version_schemes import get_version_scheme
 
 _DEFAULT_CFG: Config | None = None
 
+# Precompiled regex patterns for locating version assignments. The second
+# capture group extracts the existing version string for comparison.
+_VERSION_RE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"(__version__\s*=\s*['\"])([^'\"]+)(['\"])"),
+    re.compile(r"(VERSION\s*=\s*['\"])([^'\"]+)(['\"])"),
+    re.compile(r"(version\s*=\s*['\"])([^'\"]+)(['\"])"),
+]
+
 
 def _get_default_config() -> Config:
     """Return cached configuration loading from disk on first use.
@@ -316,15 +324,17 @@ def _replace_version(path: Path, old: str, new: str) -> bool:
     """
 
     text = path.read_text(encoding="utf-8")
-    patterns = [
-        rf"(__version__\s*=\s*['\"])({re.escape(old)})(['\"])",
-        rf"(VERSION\s*=\s*['\"])({re.escape(old)})(['\"])",
-        rf"(version\s*=\s*['\"])({re.escape(old)})(['\"])",
-    ]
     replaced = 0
-    for pat in patterns:
-        text, count = re.subn(pat, rf"\g<1>{new}\g<3>", text)
-        replaced += count
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal replaced
+        if match.group(2) != old:
+            return match.group(0)
+        replaced += 1
+        return f"{match.group(1)}{new}{match.group(3)}"
+
+    for pattern in _VERSION_RE_PATTERNS:
+        text = pattern.sub(_sub, text)
     if replaced:
         path.write_text(text, encoding="utf-8")
         return True

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,9 +4,8 @@ import pytest
 from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
-from bumpwright.config import Config, load_config
 from bumpwright import versioning
-
+from bumpwright.config import Config, load_config
 from bumpwright.versioning import (
     _replace_version,
     _resolve_files,
@@ -59,8 +58,6 @@ def test_bump_string_semver_prerelease_and_build() -> None:
 @pytest.mark.parametrize("version", ["01.2.3", "1.02.3", "1.2.03"])
 def test_bump_string_semver_rejects_leading_zeros(version: str) -> None:
     """SemVer parsing rejects numeric components with leading zeros."""
-
-
 
     with pytest.raises(ValueError):
         bump_string(version, "patch", scheme="semver")
@@ -263,6 +260,19 @@ def test_replace_version_returns_false_when_unmodified(tmp_path: Path) -> None:
 
     assert not _replace_version(target, "0.1.0", "0.2.0")
     assert target.read_text(encoding="utf-8") == "print('hello')"
+
+
+def test_replace_version_uses_module_patterns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure module-level regex patterns drive version replacement."""
+
+    target = tmp_path / "module.py"
+    target.write_text("__version__ = '0.1.0'", encoding="utf-8")
+    monkeypatch.setattr(versioning, "_VERSION_RE_PATTERNS", [])
+
+    assert not _replace_version(target, "0.1.0", "0.2.0")
+    assert target.read_text(encoding="utf-8") == "__version__ = '0.1.0'"
 
 
 def test_apply_bump_respects_scheme(


### PR DESCRIPTION
## Summary
- precompile version assignment regexes and store them at module level
- use precompiled patterns in `_replace_version`
- test `_replace_version` reliance on module-level patterns

## Testing
- `isort bumpwright/versioning.py tests/test_versioning.py`
- `black bumpwright/versioning.py tests/test_versioning.py`
- `ruff check bumpwright/versioning.py tests/test_versioning.py`
- `pytest` *(fails: SyntaxError: '(' was never closed in `bumpwright/version_schemes.py`)*


------
https://chatgpt.com/codex/tasks/task_e_68a0b183c29483228a44af4f71025ef8