### PR TITLE
refactor(versioning): cache default config without global state

### DIFF
--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
-from functools import lru_cache
+from functools import cache, lru_cache
 from glob import glob
 from pathlib import Path
 
@@ -17,9 +17,8 @@ from .config import Config, load_config
 from .types import BumpLevel
 from .version_schemes import get_version_scheme
 
-_DEFAULT_CFG: Config | None = None
 
-
+@cache
 def _get_default_config() -> Config:
     """Return cached configuration loading from disk on first use.
 
@@ -27,10 +26,7 @@ def _get_default_config() -> Config:
         Loaded :class:`~bumpwright.config.Config` instance.
     """
 
-    global _DEFAULT_CFG  # noqa: PLW0603
-    if _DEFAULT_CFG is None:
-        _DEFAULT_CFG = load_config()
-    return _DEFAULT_CFG
+    return load_config()
 
 
 @dataclass

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,9 +4,8 @@ import pytest
 from tomlkit import dumps as toml_dumps
 from tomlkit.exceptions import ParseError
 
-from bumpwright.config import Config, load_config
 from bumpwright import versioning
-
+from bumpwright.config import Config, load_config
 from bumpwright.versioning import (
     _replace_version,
     _resolve_files,
@@ -28,7 +27,7 @@ def test_bump_string():
 def test_bump_string_uses_cached_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Repeated calls reuse cached configuration."""
 
-    versioning._DEFAULT_CFG = None
+    versioning._get_default_config.cache_clear()
     calls = {"count": 0}
 
     def fake_load_config(path: str = "bumpwright.toml"):
@@ -39,7 +38,7 @@ def test_bump_string_uses_cached_config(monkeypatch: pytest.MonkeyPatch) -> None
     assert versioning.bump_string("1.0.0", "patch") == "1.0.1"
     assert versioning.bump_string("1.0.1", "patch") == "1.0.2"
     assert calls["count"] == 1
-    versioning._DEFAULT_CFG = None
+    versioning._get_default_config.cache_clear()
 
 
 def test_bump_string_semver_prerelease_and_build() -> None:
@@ -59,8 +58,6 @@ def test_bump_string_semver_prerelease_and_build() -> None:
 @pytest.mark.parametrize("version", ["01.2.3", "1.02.3", "1.2.03"])
 def test_bump_string_semver_rejects_leading_zeros(version: str) -> None:
     """SemVer parsing rejects numeric components with leading zeros."""
-
-
 
     with pytest.raises(ValueError):
         bump_string(version, "patch", scheme="semver")


### PR DESCRIPTION
## Summary
- avoid global state for default config by caching `_get_default_config`
- update tests to clear function cache instead of resetting a module variable

## Testing
- `python -m isort bumpwright/versioning.py tests/test_versioning.py`
- `python -m black bumpwright/versioning.py tests/test_versioning.py`
- `ruff check bumpwright/versioning.py tests/test_versioning.py`
- `pytest` *(fails: SyntaxError: '(' was never closed in bumpwright/version_schemes.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a0b1aa780c8322abe9b8a717bd221d