### PR TITLE
refactor(cli): replace prints with logging

### DIFF
--- a/bumpwright/cli/init.py
+++ b/bumpwright/cli/init.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import subprocess
 
 from ..gitutils import last_release_commit
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
 
 
 def init_command(_args: argparse.Namespace) -> int:
@@ -25,7 +29,7 @@ def init_command(_args: argparse.Namespace) -> int:
     """
 
     if last_release_commit() is not None:
-        print("Baseline already initialised.")
+        logger.info("Baseline already initialised.")
         return 0
 
     subprocess.run(
@@ -38,5 +42,5 @@ def init_command(_args: argparse.Namespace) -> int:
         ],
         check=True,
     )
-    print("Created baseline release commit.")
+    logger.info("Created baseline release commit.")
     return 0

--- a/tests/test_cli_analyser_flags.py
+++ b/tests/test_cli_analyser_flags.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from cli_helpers import run, setup_repo
 
 
-def _setup_cli_repo(tmp_path: Path, enable_in_config: bool = False) -> tuple[Path, str, str]:
+def _setup_cli_repo(
+    tmp_path: Path, enable_in_config: bool = False
+) -> tuple[Path, str, str]:
     """Create a repository with a CLI command that is later removed."""
     repo, pkg, _ = setup_repo(tmp_path)
     if enable_in_config:
@@ -63,10 +65,11 @@ def test_enable_analyser_flag(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    data = json.loads(res.stdout)
+    data = json.loads(res.stderr)
     assert data["level"] == "major"
     assert data["confidence"] == 1.0
     assert data["reasons"] == ["Removed command"]
@@ -95,10 +98,11 @@ def test_disable_analyser_flag(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    data = json.loads(res.stdout)
+    data = json.loads(res.stderr)
     assert data["level"] is None
     assert data["confidence"] == 0.0
     assert data["reasons"] == []

--- a/tests/test_cli_bump_decide_parity.py
+++ b/tests/test_cli_bump_decide_parity.py
@@ -13,7 +13,9 @@ def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
 
     # Modify implementation without changing the public API.
     init_file = pkg / "__init__.py"
-    init_file.write_text("def foo() -> int:\n    # no-op change\n    return 1\n", encoding="utf-8")
+    init_file.write_text(
+        "def foo() -> int:\n    # no-op change\n    return 1\n", encoding="utf-8"
+    )
     run(["git", "add", "pkg/__init__.py"], repo)
     run(["git", "commit", "-m", "chore: comment"], repo)
 
@@ -24,10 +26,11 @@ def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    assert "Suggested bump: None" in res_decide.stdout
+    assert "Suggested bump: None" in res_decide.stderr
 
     res_decide_json = subprocess.run(
         [
@@ -42,10 +45,11 @@ def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    data = json.loads(res_decide_json.stdout)
+    data = json.loads(res_decide_json.stderr)
     assert data["level"] is None
     assert data["confidence"] == 0.0
     assert data["reasons"] == []
@@ -55,7 +59,8 @@ def test_decide_flag_detects_no_api_changes(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    assert "No version bump needed" in res_bump.stdout
+    assert "No version bump needed" in res_bump.stderr

--- a/tests/test_cli_bump_format.py
+++ b/tests/test_cli_bump_format.py
@@ -28,10 +28,11 @@ def test_bump_command_json_format(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    data = json.loads(res.stdout)
+    data = json.loads(res.stderr)
     assert data["old_version"] == "0.1.0"
     assert data["new_version"] == "0.2.0"
     assert data["level"] == "minor"

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -14,7 +14,9 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -33,10 +35,11 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    output = res.stdout
+    output = res.stderr
     content = (repo / "CHANGELOG.md").read_text()
     today = date.today().isoformat()
     assert f"## [v0.1.1] - {today}" in content
@@ -47,7 +50,9 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
 def test_bump_writes_changelog(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -68,10 +73,11 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    output = res.stdout
+    output = res.stderr
     content = (repo / "CHANGELOG.md").read_text()
     today = date.today().isoformat()
     assert f"## [v0.1.1] - {today}" in content
@@ -82,7 +88,9 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
 def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -103,10 +111,11 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    output = res.stdout
+    output = res.stderr
     today = date.today().isoformat()
     assert f"## [v0.1.1] - {today}" in output
     assert f"- {sha} feat: change" in output
@@ -116,7 +125,9 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
 def test_changelog_links_repo_url(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -141,6 +152,7 @@ def test_changelog_links_repo_url(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
@@ -153,7 +165,9 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     (repo / "tpl.j2").write_text("VERSION={{ version }}\n", encoding="utf-8")
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -175,6 +189,7 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
@@ -190,7 +205,9 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -208,6 +225,7 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env=env,
     )

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -23,10 +23,11 @@ def test_bump_command_searches_pyproject(tmp_path: Path) -> None:
         cwd=pkg,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])},
     )
-    assert "Bumped version: 0.1.0 -> 0.1.1 (patch)" in res.stdout
+    assert "Bumped version: 0.1.0 -> 0.1.1 (patch)" in res.stderr
     assert read_project_version(repo / "pyproject.toml") == "0.1.1"
 
 

--- a/tests/test_cli_decide_default.py
+++ b/tests/test_cli_decide_default.py
@@ -27,11 +27,12 @@ def test_decide_flag_defaults_to_previous_commit(tmp_path: Path) -> None:
         cwd=repo,
         check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
         env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])},
     )
 
-    data = json.loads(res.stdout)
+    data = json.loads(res.stderr)
     assert data["level"] == "minor"
     assert data["confidence"] == 1.0
     assert data["reasons"] == ["Added public symbol"]


### PR DESCRIPTION
## Summary
- switch CLI commands to use module-level loggers instead of prints
- update CLI tests to capture logging output

## Testing
- `ruff check --fix bumpwright/cli/bump.py bumpwright/cli/decide.py bumpwright/cli/init.py tests/test_cli_bump_helpers.py tests/test_cli_bump_decide_parity.py tests/test_cli_changelog.py tests/test_cli_bump_format.py tests/test_cli_analyser_flags.py tests/test_cli_core.py tests/test_cli_decide_default.py`
- `isort bumpwright/cli/bump.py bumpwright/cli/decide.py bumpwright/cli/init.py tests/test_cli_bump_helpers.py tests/test_cli_bump_decide_parity.py tests/test_cli_changelog.py tests/test_cli_bump_format.py tests/test_cli_analyser_flags.py tests/test_cli_core.py tests/test_cli_decide_default.py`
- `black bumpwright/cli/bump.py bumpwright/cli/decide.py bumpwright/cli/init.py tests/test_cli_bump_helpers.py tests/test_cli_bump_decide_parity.py tests/test_cli_changelog.py tests/test_cli_bump_format.py tests/test_cli_analyser_flags.py tests/test_cli_core.py tests/test_cli_decide_default.py`
- `pytest` *(fails: SyntaxError in bumpwright/version_schemes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b19889ec8322a008f7280bfed215