### PR TITLE
docs(usage): document changelog configuration defaults

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -128,11 +128,14 @@ patterns.
 ``--changelog [FILE]``
     Append release notes for the new version to ``FILE``.
     When ``FILE`` is omitted or set to ``-``, the changelog entry is printed to
-    standard output. If the option is omitted, no changelog entry is produced.
+    standard output. If the option is omitted entirely, the
+    ``[changelog].path`` setting provides a default location. See
+    :doc:`configuration` for more detail.
 
 ``--changelog-template PATH``
     Jinja2 template file used when rendering changelog entries. Defaults to the
-    built-in template.
+    built-in template or ``[changelog].template`` when configured. See
+    :doc:`configuration` for more detail.
 
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to


### PR DESCRIPTION
## Summary
- document `[changelog].path` as default when `--changelog` is omitted
- mention `[changelog].template` for `--changelog-template`

## Testing
- `ruff check .` *(fails: SyntaxError in version_schemes.py)*
- `isort . --check-only` *(fails: imports not sorted, version_schemes.py error)*
- `black --check .` *(fails: files would be reformatted, version_schemes.py parse error)*
- `pytest` *(fails: syntax error in version_schemes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3fe65508322ba07fc90557b360f