### PR TITLE
docs(usage): prefer UK spelling for artefacts

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,7 +91,7 @@ Because this mode only inspects commits, there is no effect on the filesystem.
 Update version information in ``pyproject.toml`` and other files.
 By default, ``bumpwright`` also searches ``setup.py``, ``setup.cfg`` and any
 ``__init__.py``, ``version.py`` or ``_version.py`` files for a version
-assignment. Files inside common build artifacts and virtual environments are
+assignment. Files inside common build artefacts and virtual environments are
 ignored by default (``build/**``, ``dist/**``, ``*.egg-info/**``, ``.eggs/**``,
 ``.venv/**``, ``venv/**``, ``.env/**`` and ``**/__pycache__/**``). These
 locations can be customised via the ``[version]`` section in ``bumpwright.toml``


### PR DESCRIPTION
## Summary
- Replace US "build artifacts" with UK "build artefacts" in usage guide
- Ensure other US spellings are absent from the document

## Testing
- `ruff check .` *(fails: SyntaxError in version_schemes.py)*
- `black --check .` *(fails: would reformat files and cannot parse version_schemes.py)*
- `isort --check-only .` *(fails: imports not sorted in several files)*
- `pytest` *(fails: missing dependencies such as jinja2, tomli, tomlkit)*

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_68a0b3f9d5bc832285b14ba1cafc125d