### PR TITLE
refactor(gitutils): let subprocess.run raise errors

### DIFF
--- a/bumpwright/gitutils.py
+++ b/bumpwright/gitutils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 import subprocess
 from collections.abc import Iterable
 from fnmatch import fnmatch
@@ -30,15 +29,8 @@ def _run(cmd: list[str], cwd: str | None = None) -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        check=False,
+        check=True,
     )
-    if res.returncode != 0:
-        raise subprocess.CalledProcessError(
-            res.returncode,
-            shlex.join(cmd),
-            output=res.stdout,
-            stderr=res.stderr,
-        )
     return res.stdout
 
 

--- a/bumpwright/version_schemes.py
+++ b/bumpwright/version_schemes.py
@@ -20,7 +20,7 @@ MIN_RELEASE_PARTS = 3
 # SemVer segments disallow leading zeros per specification.
 _SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$"
-
+)
 
 
 def _bump_segment(segment: str | None, default: str) -> str:


### PR DESCRIPTION
## Summary
- rely on `subprocess.run(..., check=True)` in `_run`
- fix missing parenthesis in SemVer regex

## Testing
- `ruff check --fix bumpwright/gitutils.py`
- `black bumpwright/gitutils.py`
- `isort bumpwright/gitutils.py`
- `ruff check --fix bumpwright/version_schemes.py`
- `black bumpwright/version_schemes.py`
- `isort bumpwright/version_schemes.py`
- `pytest` *(fails: tests/test_versioning.py::test_bump_string_semver_prerelease_and_build, tests/test_versioning.py::test_bump_string_pep440_pre_and_local)*

Labels: refactor

------
https://chatgpt.com/codex/tasks/task_e_68a0b39dc364832281d6b480e49c3a58