### PR TITLE
docs(usage): drop repo-url option in decide mode

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -49,9 +49,6 @@ require.
     Output style. ``text`` prints plain console output, ``md`` emits Markdown,
     and ``json`` produces machine-readable data. Defaults to ``text``.
 
-``--repo-url URL``
-    Base repository URL for linking commit hashes in Markdown output.
-
 ``--enable-analyser NAME``
     Enable analyser ``NAME`` in addition to configuration. Repeatable.
 


### PR DESCRIPTION
## Summary
- clarify that `--repo-url` is not accepted when running `bump --decide`

## Testing
- `ruff check .` *(fails: SyntaxError in bumpwright/version_schemes.py)*
- `black docs/usage.rst` *(fails: cannot parse file)*
- `isort docs/usage.rst`
- `pytest` *(fails: SyntaxError in bumpwright/version_schemes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3ff28dc8322a4c656242ad23ad5