### PR TITLE
refactor(migrations): batch read migration files

### DIFF
--- a/bumpwright/version_schemes.py
+++ b/bumpwright/version_schemes.py
@@ -19,8 +19,8 @@ MIN_RELEASE_PARTS = 3
 
 # SemVer segments disallow leading zeros per specification.
 _SEMVER_RE = re.compile(
-    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$"
-
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$",
+)
 
 
 def _bump_segment(segment: str | None, default: str) -> str:


### PR DESCRIPTION
## Summary
- batch read migration file contents to reduce subprocess overhead
- test migration analyser across multiple files
- fix semver regex formatting

## Testing
- `pytest tests/test_migrations.py -q`
- `pytest -q` *(fails: bump_string_semver_prerelease_and_build, bump_string_pep440_pre_and_local)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b39e3104832285098b6388858a35