### PR TITLE
docs(docs): refresh usage and versioning guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,25 @@ See [docs/quickstart.rst](docs/quickstart.rst) for a step-by-step example.
 
 | Command | Purpose |
 |---------|---------|
-| `bump --decide` | Recommend a bump between two references |
-| `bump` | Apply a specific version bump |
+| `bumpwright init` | Record a baseline release commit |
+| `bumpwright bump --decide` | Recommend a bump between two references |
+| `bumpwright bump` | Apply a specific version bump |
 
-### `bump --decide` options
+### `bumpwright bump --decide` options
 
-- `--base`: base git reference
-- `--head`: head git reference
-- `--format`: output format
+- `--base`: base git reference. Defaults to the last release commit or `HEAD^`.
+- `--head`: head git reference. Defaults to `HEAD`.
+- `--format`: output format (`text`, `md`, or `json`). Defaults to `text`.
 - `--enable-analyser` or `--disable-analyser`: toggle analysers
 - See [CLI reference](docs/cli_reference.rst) for details.
 
-### `bump` options
+### `bumpwright bump` options
 
-- `--level`: bump level to apply
-- `--pyproject`: path to pyproject file
-- `--format`: output format
-- `--commit`: commit the version bump
-- `--tag`: create a git tag
+- `--level`: bump level to apply. When omitted, the level is inferred from history.
+- `--pyproject`: path to `pyproject.toml`. Defaults to `pyproject.toml` in the current directory.
+- `--format`: output format (`text`, `md`, or `json`). Defaults to `text`.
+- `--commit`: commit the version bump.
+- `--tag`: create a git tag.
 - `--enable-analyser` or `--disable-analyser`: toggle analysers
 - See [CLI reference](docs/cli_reference.rst) for details.
 
@@ -91,14 +92,14 @@ aborts if uncommitted changes are detected.
 2. **Suggest the next version** between two git references:
 
    ```console
-   $ bumpwright bump --decide --base origin/main --head HEAD --format text
+   $ bumpwright bump --decide --base origin/main --format text
    bumpwright suggests: minor
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```
 
    ```console
-   $ bumpwright bump --decide --base origin/main --head HEAD --format md
+   $ bumpwright bump --decide --base origin/main --format md
    **bumpwright** suggests: `minor`
 
 
@@ -106,7 +107,7 @@ aborts if uncommitted changes are detected.
    ```
 
    ```console
-   $ bumpwright bump --decide --base origin/main --head HEAD --format json
+   $ bumpwright bump --decide --base origin/main --format json
    {
      "level": "minor",
      "confidence": 1.0,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -160,7 +160,7 @@ scheme is applied.
      - str
      - ``"semver"``
      - Versioning scheme used when bumping. Supported values include
-       ``"semver"`` and ``"pep440"``.
+       ``"semver"`` and ``"pep440"``. See :doc:`../versioning` for details.
 
 Version replacement ignores build and environment artefacts by default:
 ``build/**``, ``dist/**``, ``*.egg-info/**``, ``.eggs/**``, ``.venv/**``,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -67,6 +67,16 @@ Start with a tiny example project to see **bumpwright** in action.
    semantic version. The lines following the suggestion list the impacts that
    informed it.
 
+#. Apply the bump and tag the release.
+
+   .. code-block:: bash
+
+      bumpwright bump --commit --tag
+
+   This updates version files, creates a ``chore(release): <version>`` commit,
+   and tags the release. Omit ``--commit`` and ``--tag`` to preview the bump
+   without modifying the repository.
+
 Flow
 ----
 
@@ -79,6 +89,12 @@ Flow
        |
        v
    Version recommendation
+       |
+       v
+   bumpwright bump --commit --tag
+       |
+       v
+   Release
 
 For deeper explanations of commands, flags, and configuration, see
 :doc:`usage` and :doc:`configuration`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,8 +29,8 @@ release commits.
    bumpwright init
 
 
-``bump --decide`` – suggest a bump
-----------------------------------
+``bumpwright bump --decide`` – suggest a bump
+---------------------------------------------
 
 Compare two git references and report the semantic version level they
 require.
@@ -82,8 +82,8 @@ Because this mode only inspects commits, there is no effect on the filesystem.
 
 
 
-``bump`` – apply a bump
------------------------
+``bumpwright bump`` – apply a bump
+----------------------------------
 
 Update version information in ``pyproject.toml`` and other files.
 By default, ``bumpwright`` also searches ``setup.py``, ``setup.cfg`` and any

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,16 +1,18 @@
 Versioning
 ==========
 
-``bumpwright`` provides multiple versioning schemes. Release-level bumps
+``bumpwright`` supports multiple versioning schemes. The CLI defaults to
+Semantic Versioning (``semver``) but can operate in `PEP 440`_ mode by setting
+``[version].scheme = "pep440"`` in ``bumpwright.toml``. Release-level bumps
 (``major``, ``minor``, ``patch``) reset any prerelease or build/local segments.
-Use the dedicated ``pre`` and ``build`` levels to update those segments
-independently.
+Library callers may use the dedicated ``pre`` and ``build`` levels to update
+those segments independently.
 
 .. note::
 
-   The :func:`bumpwright.versioning.bump_string` utility supports
-   additional ``pre`` and ``build`` increments. The CLI exposes only the
-   ``major``, ``minor``, and ``patch`` levels.
+   The :func:`bumpwright.versioning.bump_string` helper accepts the extra
+   ``pre`` and ``build`` levels. The command-line interface exposes only the
+   ``major``, ``minor``, and ``patch`` options.
 
 SemVer
 ------
@@ -43,3 +45,5 @@ release bumps drop these components:
 
 Use these bump levels to manage prerelease and build metadata without altering
 the main release components.
+
+.. _PEP 440: https://peps.python.org/pep-0440/


### PR DESCRIPTION
## Summary
- clarify CLI commands and defaults in README quick start
- document bumpwright bump behaviours and defaults
- explain version scheme selection and add release workflow example

## Testing
- `ruff check bumpwright`
- `black --check bumpwright` *(fails: would reformat 7 files)*
- `isort --check-only bumpwright` *(fails: imports not sorted)*
- `pytest` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b5b8580083228ecc815bf56759c9