### PR TITLE
refactor(config): derive defaults from dataclasses

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import tomli
 
-from bumpwright.config import load_config
+from bumpwright.config import Config, load_config
 
 
 def test_load_config_parses_analysers(tmp_path: Path) -> None:
@@ -66,13 +66,12 @@ def test_tomli_fallback(monkeypatch, tmp_path: Path) -> None:
 def test_mutating_config_does_not_alter_defaults(tmp_path: Path) -> None:
     """Ensure modifying a loaded config leaves defaults unchanged."""
 
+    defaults = Config()
     cfg = load_config(tmp_path / "missing.toml")
     cfg.project.public_roots.append("src")
 
-    import bumpwright.config as config_module  # noqa: PLC0415
-
     fresh = load_config(tmp_path / "missing.toml")
-    assert config_module._DEFAULTS["project"]["public_roots"] == ["."]
+    assert defaults.project.public_roots == ["."]
     assert fresh.project.public_roots == ["."]
 
 


### PR DESCRIPTION
## Summary
- derive configuration defaults from dataclasses via `asdict` and merge user overrides
- drop duplicated `_DEFAULTS` mapping
- update config tests to rely on dataclass defaults

## Testing
- `python -m isort bumpwright/config.py tests/test_config.py`
- `python -m black bumpwright/config.py tests/test_config.py`
- `python -m ruff check bumpwright/config.py tests/test_config.py`
- `pytest` *(fails: test_bump_string_semver_prerelease_and_build, test_bump_string_pep440_pre_and_local)*

Labels: refactor

------
https://chatgpt.com/codex/tasks/task_e_68a0b6a6d75883229d640aa511e69778