### PR TITLE
refactor(versioning): remove unused default config

### DIFF
--- a/bumpwright/versioning.py
+++ b/bumpwright/versioning.py
@@ -17,9 +17,6 @@ from .config import Config, load_config
 from .types import BumpLevel
 from .version_schemes import get_version_scheme
 
-
-_DEFAULT_CFG: Config | None = None
-
 # Precompiled regex patterns for locating version assignments. The second
 # capture group extracts the existing version string for comparison.
 _VERSION_RE_PATTERNS: list[re.Pattern[str]] = [


### PR DESCRIPTION
## Summary
- remove unused module-level `_DEFAULT_CFG` variable and rely on `_get_default_config()` for cached configuration

## Testing
- `python -m isort bumpwright/versioning.py`
- `python -m black bumpwright/versioning.py`
- `ruff check bumpwright/versioning.py`
- `pytest -q` *(fails: assertion errors in `tests/test_versioning.py::test_bump_string_semver_prerelease_and_build` and `tests/test_versioning.py::test_bump_string_pep440_pre_and_local`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b6a940b88322b1841cf64cee77b9