### PR TITLE
docs(api): expand module docstrings for public API and web-route analysers

### DIFF
--- a/bumpwright/analysers/web_routes.py
+++ b/bumpwright/analysers/web_routes.py
@@ -1,4 +1,11 @@
-"""Analyze HTTP route decorators to compare endpoints across git references."""
+"""Detect changes in web application routes across git references.
+
+The analyser walks Python modules looking for decorator-based route
+definitions used by frameworks such as Flask or FastAPI.  It compares the
+collected routes between revisions to flag additions, removals, and parameter
+changes.  Only straightforward decorator patterns are recognised, so routes
+registered dynamically or via framework-specific helpers may be missed.
+"""
 
 from __future__ import annotations
 
@@ -65,8 +72,14 @@ def extract_routes_from_source(code: str) -> dict[tuple[str, str], Route]:
                     if deco.args and _is_const_str(deco.args[0]):
                         path = deco.args[0].value  # type: ignore[assignment]
                     for kw in deco.keywords:
-                        if kw.arg == "methods" and isinstance(kw.value, (ast.List, ast.Tuple)):
-                            methods = [elt.value.upper() for elt in kw.value.elts if _is_const_str(elt)]
+                        if kw.arg == "methods" and isinstance(
+                            kw.value, (ast.List, ast.Tuple)
+                        ):
+                            methods = [
+                                elt.value.upper()
+                                for elt in kw.value.elts
+                                if _is_const_str(elt)
+                            ]
                     if methods is None:
                         methods = ["GET"]
                 elif name.upper() in HTTP_METHODS:  # FastAPI style
@@ -80,7 +93,9 @@ def extract_routes_from_source(code: str) -> dict[tuple[str, str], Route]:
     return routes
 
 
-def _build_routes_at_ref(ref: str, roots: Iterable[str], ignores: Iterable[str]) -> dict[tuple[str, str], Route]:
+def _build_routes_at_ref(
+    ref: str, roots: Iterable[str], ignores: Iterable[str]
+) -> dict[tuple[str, str], Route]:
     """Collect routes for all modules under given roots at a git ref.
 
     Args:
@@ -98,7 +113,9 @@ def _build_routes_at_ref(ref: str, roots: Iterable[str], ignores: Iterable[str])
     return out
 
 
-def diff_routes(old: dict[tuple[str, str], Route], new: dict[tuple[str, str], Route]) -> list[Impact]:
+def diff_routes(
+    old: dict[tuple[str, str], Route], new: dict[tuple[str, str], Route]
+) -> list[Impact]:
     """Compute impacts between two route mappings.
 
     Args:
@@ -160,9 +177,13 @@ class WebRoutesAnalyser:
             Mapping of ``(path, method)`` to :class:`Route` objects.
         """
 
-        return _build_routes_at_ref(ref, self.cfg.project.public_roots, self.cfg.ignore.paths)
+        return _build_routes_at_ref(
+            ref, self.cfg.project.public_roots, self.cfg.ignore.paths
+        )
 
-    def compare(self, old: dict[tuple[str, str], Route], new: dict[tuple[str, str], Route]) -> list[Impact]:
+    def compare(
+        self, old: dict[tuple[str, str], Route], new: dict[tuple[str, str], Route]
+    ) -> list[Impact]:
         """Compare two route mappings and return impacts.
 
         Args:

--- a/bumpwright/public_api.py
+++ b/bumpwright/public_api.py
@@ -1,8 +1,9 @@
-"""Extract and represent a package's public API using the stdlib AST.
+"""Extract a package's public surface by statically parsing source code.
 
-This module inspects Python source code to determine the exposed public API.
-It uses :mod:`ast` to avoid heavyweight third‑party dependencies while still
-capturing function and method signatures accurately.
+The module relies solely on the standard library :mod:`ast` package to map
+exported functions and methods and capture their signatures.  Only a narrow
+subset of ``__all__`` expressions is evaluated and no user code is executed,
+so dynamically constructed symbols or runtime side effects may be missed.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- clarify AST-based public API extraction
- document web-route analyser limitations and responsibilities

## Testing
- `isort bumpwright/public_api.py bumpwright/analysers/web_routes.py`
- `black bumpwright/public_api.py bumpwright/analysers/web_routes.py`
- `ruff check bumpwright/public_api.py bumpwright/analysers/web_routes.py`
- `pytest`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_68a0baf9488883228da631cfb07465e0