### PR TITLE
docs(ci): document github sha and permissions

### DIFF
--- a/docs/_static/workflows/bumpwright-auto-bump.yml
+++ b/docs/_static/workflows/bumpwright-auto-bump.yml
@@ -10,7 +10,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # allow committing and tagging
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/docs/_static/workflows/bumpwright-release.yml
+++ b/docs/_static/workflows/bumpwright-release.yml
@@ -15,10 +15,12 @@ on:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # allow committing and tagging
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}  # token with permissions to push
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -26,7 +28,7 @@ jobs:
         run: pip install bumpwright
       - name: Apply version bump
         run: |
-          bumpwright bump --level ${{ github.event.inputs.level }} \
+          bumpwright bump --level ${{ github.event.inputs.level }} \  # level from workflow input
             --pyproject pyproject.toml --commit --tag
       - name: Push changes
         run: git push origin HEAD --follow-tags

--- a/docs/guides/advanced/ci_pipelines.rst
+++ b/docs/guides/advanced/ci_pipelines.rst
@@ -18,6 +18,10 @@ Integrating with CI pipelines
          - run: pip install bumpwright
          - run: bumpwright bump --decide --base origin/main --head ${{ github.sha }}
 
+   ``${{ github.sha }}`` resolves to the commit SHA for the workflow run.
+   Workflows that commit or tag must grant ``contents: write`` via
+   ``permissions`` and authenticate with the default ``GITHUB_TOKEN``.
+
 2. Review the workflow logs to see the suggested bump:
 
 .. code-block:: text


### PR DESCRIPTION
## Summary
- document `${{ github.sha }}` usage in CI guide and note required `contents: write` permissions
- clarify workflow permissions for committing and tagging

## Testing
- `ruff check --fix .`
- `black .`
- `isort .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bbb22c948322993f60054ee5d75f