### PR TITLE
docs(quickstart): clarify comparison and output formats

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -65,7 +65,25 @@ Start with a tiny example project to see **bumpwright** in action.
 
    ``bumpwright`` inspects commits since the baseline and suggests the next
    semantic version. The lines following the suggestion list the impacts that
-   informed it.
+   informed it. Note that ``bumpwright bump --decide`` compares ``HEAD`` to the
+   last release or ``HEAD^``.
+
+   .. code-block:: bash
+
+      bumpwright bump --decide --format md
+
+   .. code-block:: text
+
+      ## Suggested bump: minor
+      - [MINOR] demo:greet: Added public symbol
+
+   .. code-block:: bash
+
+      bumpwright bump --decide --format json
+
+   .. code-block:: json
+
+      {"suggested_bump": "minor", "impacts": [{"scope": "demo:greet", "level": "MINOR", "description": "Added public symbol"}]}
 
 #. Apply the bump and tag the release.
 
@@ -74,8 +92,9 @@ Start with a tiny example project to see **bumpwright** in action.
       bumpwright bump --commit --tag
 
    This updates version files, creates a ``chore(release): <version>`` commit,
-   and tags the release. Omit ``--commit`` and ``--tag`` to preview the bump
-   without modifying the repository.
+   and tags the release. When ``--commit`` is used, this is the default commit
+   message. Omit ``--commit`` and ``--tag`` to preview the bump without
+   modifying the repository.
 
 Flow
 ----


### PR DESCRIPTION
## Summary
- document how `bumpwright bump --decide` compares `HEAD` to the last release or `HEAD^`
- add markdown and JSON format examples for `bumpwright bump`
- note the default commit message used when `--commit` is invoked

## Testing
- `ruff check .`
- `isort docs/quickstart.rst --check-only`
- `black docs --check`
- `pytest`

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_68a0bd4ea1e88322b869305ffae62f13