### PR TITLE
docs(versioning): clarify bump levels and return type severity

### DIFF
--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -14,6 +14,44 @@ those segments independently.
    ``pre`` and ``build`` levels. The command-line interface exposes only the
    ``major``, ``minor``, and ``patch`` options.
 
+.. list-table:: Bump level effects
+   :header-rows: 1
+
+   * - Level
+     - Prerelease segment
+     - Build/local segment
+   * - ``major``
+     - cleared
+     - cleared
+   * - ``minor``
+     - cleared
+     - cleared
+   * - ``patch``
+     - cleared
+     - cleared
+   * - ``pre``
+     - incremented
+     - unchanged
+   * - ``build``
+     - unchanged
+     - incremented
+
+Examples using the default SemVer scheme:
+
+.. code-block:: python
+
+   from bumpwright.versioning import bump_string
+   bump_string("1.0.0-alpha.1", "pre", scheme="semver")    # 1.0.0-alpha.2
+   bump_string("1.0.0+build.1", "build", scheme="semver")  # 1.0.0+build.2
+
+Return type changes are treated as a ``minor`` bump by default. Override this
+behavior via ``rules.return_type_change`` in :doc:`configuration`:
+
+.. code-block:: toml
+
+   [rules]
+   return_type_change = "major"
+
 SemVer
 ------
 


### PR DESCRIPTION
## Summary
- document behavior of prerelease and build segments for each bump level
- show bump_string examples for pre and build increments
- explain how to override default minor severity via rules.return_type_change

## Testing
- `ruff check .`
- `black --check docs`
- `isort --check-only docs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd53eb4c83228fcb484f2ebd9f7b