### PR TITLE
fix(cli): use glob.has_magic for wildcard paths

### DIFF
--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 from datetime import date
+from glob import has_magic
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -188,7 +189,7 @@ def _prepare_version_files(
     paths = list(cfg.version.paths)
     if args.version_path:
         paths.extend(args.version_path)
-    version_files = {p for p in paths if not any(ch in p for ch in "*?[")}
+    version_files = {p for p in paths if not has_magic(p)}
     changed = _safe_changed_paths(base, head)
     if changed is not None:
         filtered = {


### PR DESCRIPTION
## Summary
- use glob.has_magic to detect wildcard paths in version file preparation
- test wildcard directory handling in CLI helpers

## Testing
- `ruff check bumpwright/cli/bump.py tests/test_cli_bump_helpers.py --fix`
- `black bumpwright/cli/bump.py tests/test_cli_bump_helpers.py`
- `isort bumpwright/cli/bump.py tests/test_cli_bump_helpers.py`
- `pytest tests/test_cli_bump_helpers.py::test_prepare_version_files_no_relevant_changes tests/test_cli_bump_helpers.py::test_prepare_version_files_wildcard_directory`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1b4cdcc8322aa8e086f4937673b