### PR TITLE
refactor(utils): batch read Python files

### DIFF
--- a/bumpwright/analysers/utils.py
+++ b/bumpwright/analysers/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 from collections.abc import Iterable, Iterator
 
-from ..gitutils import list_py_files_at_ref, read_file_at_ref
+from ..gitutils import list_py_files_at_ref, read_files_at_ref
 
 
 def _is_const_str(node: ast.AST) -> bool:
@@ -39,7 +39,9 @@ def iter_py_files_at_ref(
         Tuples of ``(path, source)`` for each discovered Python file.
     """
 
-    for path in list_py_files_at_ref(ref, roots, ignore_globs=ignore_globs, cwd=cwd):
-        code = read_file_at_ref(ref, path, cwd=cwd)
+    paths = list(list_py_files_at_ref(ref, roots, ignore_globs=ignore_globs, cwd=cwd))
+    contents = read_files_at_ref(ref, paths, cwd=cwd)
+    for path in paths:
+        code = contents.get(path)
         if code is not None:
             yield path, code


### PR DESCRIPTION
## Summary
- batch read Python files in `iter_py_files_at_ref`
- test single git call when iterating python files

## Testing
- `isort bumpwright/analysers/utils.py tests/test_analysers_utils.py`
- `black bumpwright/analysers/utils.py tests/test_analysers_utils.py`
- `ruff check bumpwright/analysers/utils.py tests/test_analysers_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1afd4ec83229b161e5cdc4fa402