### PR TITLE
feat(analysers): cache parsed sources for faster analyses

### DIFF
--- a/bumpwright/analysers/utils.py
+++ b/bumpwright/analysers/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from collections.abc import Iterable, Iterator
+from functools import lru_cache
 
 from ..gitutils import list_py_files_at_ref, read_file_at_ref
 
@@ -19,6 +20,30 @@ def _is_const_str(node: ast.AST) -> bool:
     """
 
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+@lru_cache(maxsize=None)
+def parse_python_source(ref: str, path: str, cwd: str | None = None) -> ast.AST | None:
+    """Return the parsed AST for ``path`` at ``ref``.
+
+    Results are cached per ``(ref, path, cwd)`` to avoid repeated git
+    lookups and ``ast.parse`` calls when analysers inspect the same files
+    multiple times.
+
+    Args:
+        ref: Git reference of the file to parse.
+        path: File path relative to the repository root.
+        cwd: Repository path. Defaults to the current working directory.
+
+    Returns:
+        Parsed module AST or ``None`` if the file does not exist at
+        ``ref``.
+    """
+
+    code = read_file_at_ref(ref, path, cwd=cwd)
+    if code is None:
+        return None
+    return ast.parse(code)
 
 
 def iter_py_files_at_ref(
@@ -43,3 +68,11 @@ def iter_py_files_at_ref(
         code = read_file_at_ref(ref, path, cwd=cwd)
         if code is not None:
             yield path, code
+
+
+def clear_caches() -> None:
+    """Clear caches used by analyser utilities."""
+
+    parse_python_source.cache_clear()
+    list_py_files_at_ref.cache_clear()
+    read_file_at_ref.cache_clear()

--- a/bumpwright/cli/decide.py
+++ b/bumpwright/cli/decide.py
@@ -9,10 +9,10 @@ import subprocess
 from collections.abc import Iterable
 
 from ..analysers import get_analyser_info
-from ..analysers.utils import iter_py_files_at_ref
+from ..analysers.utils import parse_python_source
 from ..compare import Decision, Impact, decide_bump, diff_public_api
 from ..config import Config
-from ..gitutils import last_release_commit
+from ..gitutils import last_release_commit, list_py_files_at_ref
 from ..public_api import (
     PublicAPI,
     extract_public_api_from_source,
@@ -29,11 +29,13 @@ def _build_api_at_ref(ref: str, roots: list[str], ignores: Iterable[str]) -> Pub
 
     api: PublicAPI = {}
     for root in roots:
-        for path, code in sorted(
-            iter_py_files_at_ref(ref, [root], ignores), key=lambda t: t[0]
-        ):
+        paths = sorted(list_py_files_at_ref(ref, [root], ignore_globs=ignores))
+        for path in paths:
+            tree = parse_python_source(ref, path)
+            if tree is None:
+                continue
             modname = module_name_from_path(root, path)
-            api.update(extract_public_api_from_source(modname, code))
+            api.update(extract_public_api_from_source(modname, tree))
     return api
 
 

--- a/bumpwright/public_api.py
+++ b/bumpwright/public_api.py
@@ -302,18 +302,18 @@ def module_name_from_path(root: str, path: str) -> str:
     return ".".join(rel.parts)
 
 
-def extract_public_api_from_source(module_name: str, code: str) -> PublicAPI:
+def extract_public_api_from_source(module_name: str, code: str | ast.AST) -> PublicAPI:
     """Extract the public API from Python source code.
 
     Args:
         module_name: Name of the module represented by ``code``.
-        code: Source code to analyze.
+        code: Source text or a pre-parsed module AST.
 
     Returns:
         Mapping of symbol names to :class:`FuncSig` objects.
     """
 
-    mod = ast.parse(code)
+    mod = ast.parse(code) if isinstance(code, str) else code
     exports = _parse_exports(mod)
     visitor = _APIVisitor(module_name, exports)
     visitor.visit(mod)

--- a/tests/test_parse_cache.py
+++ b/tests/test_parse_cache.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from bumpwright import gitutils
+from bumpwright.analysers.cli import _build_cli_at_ref
+from bumpwright.analysers.utils import clear_caches, parse_python_source
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a git repository with a simple CLI module."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pkg = repo / "pkg"
+    pkg.mkdir()
+    (pkg / "cli.py").write_text(
+        """
+import click
+
+@click.command()
+def main() -> None:
+    pass
+"""
+    )
+    gitutils._run(["git", "init"], str(repo))
+    gitutils._run(["git", "config", "user.email", "test@example.com"], str(repo))
+    gitutils._run(["git", "config", "user.name", "Test"], str(repo))
+    gitutils._run(["git", "add", "."], str(repo))
+    gitutils._run(["git", "commit", "-m", "init"], str(repo))
+    return repo
+
+
+def test_parse_python_source_caches(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    clear_caches()
+    path = "pkg/cli.py"
+    with (
+        patch(
+            "bumpwright.analysers.utils.read_file_at_ref",
+            wraps=gitutils.read_file_at_ref,
+        ) as rf,
+        patch("bumpwright.analysers.utils.ast.parse", wraps=ast.parse) as ap,
+    ):
+        tree1 = parse_python_source("HEAD", path, str(repo))
+        tree2 = parse_python_source("HEAD", path, str(repo))
+        assert tree1 is tree2
+        assert rf.call_count == 1  # noqa: PLR2004
+        assert ap.call_count == 1  # noqa: PLR2004
+        clear_caches()
+        parse_python_source("HEAD", path, str(repo))
+        assert rf.call_count == 2  # noqa: PLR2004
+        assert ap.call_count == 2  # noqa: PLR2004
+
+
+def test_build_cli_uses_cached_ast(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    clear_caches()
+    with patch("bumpwright.analysers.utils.ast.parse", wraps=ast.parse) as ap:
+        old = os.getcwd()
+        os.chdir(repo)
+        try:
+            _build_cli_at_ref("HEAD", ["pkg"], [])
+            _build_cli_at_ref("HEAD", ["pkg"], [])
+        finally:
+            os.chdir(old)
+        assert ap.call_count == 1  # noqa: PLR2004


### PR DESCRIPTION
## Summary
- add memoized `parse_python_source` and cache clearing helper
- refactor analysers and CLI to reuse cached ASTs
- test AST cache to demonstrate fewer git calls/parses

## Testing
- `ruff check --fix .`
- `isort bumpwright/analysers/cli.py bumpwright/analysers/utils.py bumpwright/analysers/web_routes.py bumpwright/cli/decide.py bumpwright/public_api.py tests/test_parse_cache.py`
- `black bumpwright/analysers/cli.py bumpwright/analysers/utils.py bumpwright/analysers/web_routes.py bumpwright/cli/decide.py bumpwright/public_api.py tests/test_parse_cache.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c1c101a88322bfb1c9a109e373fe