### PR TITLE
docs(index): expand overview and comparisons

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,58 @@ recommend the appropriate semantic version increment. It is designed for
 library maintainers, continuous integration systems, and release managers who
 need a reliable view of how code changes affect downstream consumers.
 
+Why Bumpwright?
+---------------
+
+Semantic versioning only works when release numbers reflect the true impact of
+code changes. Tracking every public entry point by hand is tedious and
+error-prone. Bumpwright automates this process with static analysis so you can
+ship confident releases without manual bookkeeping.
+
+How It Works
+------------
+
+Bumpwright compares two git references, builds a model of the public API for
+each, and uses heuristics to determine whether changes are major, minor, or
+patch level. The tool outputs a recommended bump and a list of detected
+impacts, making it simple to understand the reasoning behind the suggestion.
+
+Key Features
+------------
+
+- Static diff of functions, classes, and other exported symbols.
+- Pluggable analysers for command-line interfaces, web routes, and database
+  migrations.
+- Dry-run mode to preview changes without touching files.
+- Output in plain text, Markdown, or JSON for easy integration.
+
+Comparison to Similar Tools
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Approach
+     - Best for
+     - Limitations
+   * - Bumpwright
+     - Public API analysis with heuristics
+     - Libraries that expose a stable API
+     - Requires a baseline reference
+   * - bump2version
+     - Manual version string management
+     - Small projects with manual release workflow
+     - No analysis of code changes
+   * - semantic-release
+     - Commit message conventions
+     - Teams with disciplined commit history
+     - Ignores actual API surface
+   * - Release Please
+     - Structured commit messages and release PRs
+     - Mono-repos and automated PR-based releases
+     - Doesn't inspect API changes
+
 Getting Started
 ---------------
 
@@ -46,3 +98,9 @@ Project Resources
    troubleshooting
    performance
    roadmap
+
+Community and Feedback
+----------------------
+
+Found a bug or have an idea? Open an issue or pull request on the project's
+GitHub page to help make Bumpwright better.


### PR DESCRIPTION
## Summary
- expand project overview with motivation, workflow, and key feature sections
- add comparison table contrasting Bumpwright with bump2version, semantic-release, and Release Please
- note contribution avenues for community feedback

## Testing
- `ruff check .` *(fails: Undefined name `read_file_at_ref`)*
- `isort . --check-only` *(fails: tests/test_analyser_registry.py imports incorrectly sorted)*
- `black . --check` *(fails: 4 files would be reformatted)*
- `pytest` *(fails: NameError: `read_file_at_ref` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c63e595c83229fced999c74a6396