### PR TITLE
feat(config): validate return type change rule

### DIFF
--- a/bumpwright/analysers/utils.py
+++ b/bumpwright/analysers/utils.py
@@ -6,7 +6,7 @@ import ast
 from collections.abc import Iterable, Iterator
 from functools import lru_cache
 
-from ..gitutils import list_py_files_at_ref, read_files_at_ref
+from ..gitutils import list_py_files_at_ref, read_file_at_ref, read_files_at_ref
 
 
 def _is_const_str(node: ast.AST) -> bool:

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -10,12 +10,29 @@ import copy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from .types import BumpLevel
+
 
 @dataclass
 class Rules:
-    """Rules controlling version bump decisions."""
+    """Rules controlling version bump decisions.
 
-    return_type_change: str = "minor"  # "minor" | "major"
+    Attributes:
+        return_type_change: Version bump level triggered when a public API
+            return type changes.
+    """
+
+    return_type_change: BumpLevel = "minor"
+
+    def __post_init__(self) -> None:
+        """Validate rule configuration.
+
+        Raises:
+            ValueError: If ``return_type_change`` is not ``"major"`` or ``"minor"``.
+        """
+
+        if self.return_type_change not in {"major", "minor"}:
+            raise ValueError("return_type_change must be 'major' or 'minor'")
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import tomli
 
-from bumpwright.config import Config, load_config
+from bumpwright.config import Config, Rules, load_config
 
 
 def test_load_config_parses_analysers(tmp_path: Path) -> None:
@@ -115,3 +115,19 @@ def test_unknown_key_in_section(tmp_path: Path) -> None:
         load_config(cfg_file)
     message = str(exc.value)
     assert "project" in message and "unknown" in message
+
+
+def test_rules_invalid_return_type_change() -> None:
+    """Reject unsupported return type change levels."""
+
+    with pytest.raises(ValueError):
+        Rules(return_type_change="patch")
+
+
+def test_load_config_invalid_return_type_change(tmp_path: Path) -> None:
+    """Raise an error when config specifies an invalid return type change."""
+
+    cfg_file = tmp_path / "bumpwright.toml"
+    cfg_file.write_text("[rules]\nreturn_type_change='patch'\n")
+    with pytest.raises(ValueError):
+        load_config(cfg_file)


### PR DESCRIPTION
## Summary
- validate `return_type_change` configuration with strict allowed values
- test invalid `return_type_change` inputs
- import missing `read_file_at_ref` for analyser utilities

## Testing
- `isort bumpwright/config.py tests/test_config.py bumpwright/analysers/utils.py`
- `black bumpwright/config.py tests/test_config.py bumpwright/analysers/utils.py`
- `ruff check bumpwright/config.py tests/test_config.py bumpwright/analysers/utils.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c6967a988322b801b2a7931cb102