### PR TITLE
test(web-routes): add coverage for flask multi-method routes

### DIFF
--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,11 +1,21 @@
-from bumpwright.analysers.web_routes import diff_routes, extract_routes_from_source
+from __future__ import annotations
+
+from bumpwright.analysers.web_routes import (
+    Route,
+    diff_routes,
+    extract_routes_from_source,
+)
 
 
-def _build(src: str):
+def _build(src: str) -> dict[tuple[str, str], Route]:
+    """Parse source code into a route mapping."""
+
     return extract_routes_from_source(src)
 
 
-def test_removed_route_is_major():
+def test_removed_route_is_major() -> None:
+    """Removing an existing route triggers a major impact."""
+
     old = _build(
         """
 from flask import Flask
@@ -16,12 +26,14 @@ def a():
     return 'ok'
 """
     )
-    new = {}
+    new: dict[tuple[str, str], Route] = {}
     impacts = diff_routes(old, new)
     assert any(i.severity == "major" for i in impacts)
 
 
-def test_param_optional_to_required_is_major():
+def test_param_optional_to_required_is_major() -> None:
+    """Making an optional parameter required is a major impact."""
+
     old = _build(
         """
 from fastapi import FastAPI
@@ -46,7 +58,9 @@ def a(q: int):
     assert any(i.severity == "major" for i in impacts)
 
 
-def test_added_query_param_is_minor():
+def test_added_query_param_is_minor() -> None:
+    """Adding an optional query parameter is a minor impact."""
+
     old = _build(
         """
 from fastapi import FastAPI
@@ -71,7 +85,9 @@ def a(limit: int | None = None):
     assert any(i.severity == "minor" for i in impacts)
 
 
-def test_async_route_detected():
+def test_async_route_detected() -> None:
+    """Async routes should still be detected."""
+
     routes = _build(
         """
 from fastapi import FastAPI
@@ -83,3 +99,20 @@ async def a():
 """
     )
     assert ("/a", "GET") in routes
+
+
+def test_flask_multiple_methods_extracted() -> None:
+    """Flask routes with multiple methods should produce entries per method."""
+
+    routes = _build(
+        """
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/a", methods=["POST", "PUT"])
+def a():
+    return "ok"
+"""
+    )
+    assert ("/a", "POST") in routes
+    assert ("/a", "PUT") in routes


### PR DESCRIPTION
## Summary
- add test to ensure flask routes with multiple methods generate individual entries

## Testing
- `isort tests/test_web_routes.py`
- `black tests/test_web_routes.py`
- `ruff check tests/test_web_routes.py --fix`
- `pytest tests/test_web_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c98a655c8322a2e8db80361f197a