### PR TITLE
docs(readme): clarify bump suggestion wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ aborts if uncommitted changes are detected.
 
    ```console
    $ bumpwright bump --decide --base origin/main --format text
-   bumpwright suggests: minor
+   Suggested bump: minor
 
    - [MINOR] cli.new_command: added CLI entry 'greet'
    ```


### PR DESCRIPTION
## Summary
- clarify bump suggestion wording in README example

## Testing
- `ruff check .`
- `black --check bumpwright`
- `isort --check-only bumpwright -v`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb2fda8883228c34c33a19372156