### PR TITLE
feat(graphql-analyser): add GraphQL schema analyser

### DIFF
--- a/bumpwright/analysers/__init__.py
+++ b/bumpwright/analysers/__init__.py
@@ -103,7 +103,7 @@ def get_analyser_info(name: str) -> AnalyserInfo | None:
 # Import built-in analysers for registration side-effects
 # isort: off
 # fmt: off
-from . import cli, migrations, web_routes  # noqa: F401,E402  # pylint: disable=wrong-import-position
+from . import cli, graphql, migrations, web_routes  # noqa: F401,E402  # pylint: disable=wrong-import-position
 # fmt: on
 # isort: on
 

--- a/bumpwright/analysers/graphql.py
+++ b/bumpwright/analysers/graphql.py
@@ -1,0 +1,161 @@
+"""Analyse GraphQL schema files for breaking changes."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+from graphql import parse
+from graphql.language import (
+    EnumTypeDefinitionNode,
+    InputObjectTypeDefinitionNode,
+    InterfaceTypeDefinitionNode,
+    ObjectTypeDefinitionNode,
+    ScalarTypeDefinitionNode,
+    UnionTypeDefinitionNode,
+)
+
+from ..compare import Impact
+from ..config import Config
+from ..gitutils import read_files_at_ref
+from . import register
+
+
+@dataclass(frozen=True)
+class TypeDef:
+    """Represent a GraphQL type and its fields."""
+
+    name: str
+    fields: frozenset[str]
+
+
+def extract_types_from_schema(sdl: str) -> dict[str, TypeDef]:
+    """Parse GraphQL SDL into type definitions.
+
+    Args:
+        sdl: GraphQL schema definition language string.
+
+    Returns:
+        Mapping of type name to :class:`TypeDef` objects.
+    """
+
+    doc = parse(sdl)
+    out: dict[str, TypeDef] = {}
+    for defn in doc.definitions:
+        if isinstance(
+            defn,
+            (
+                ObjectTypeDefinitionNode,
+                InterfaceTypeDefinitionNode,
+                InputObjectTypeDefinitionNode,
+            ),
+        ):
+            fields = frozenset(field.name.value for field in (defn.fields or []))
+            out[defn.name.value] = TypeDef(defn.name.value, fields)
+        elif isinstance(
+            defn,
+            (EnumTypeDefinitionNode, UnionTypeDefinitionNode, ScalarTypeDefinitionNode),
+        ):
+            out[defn.name.value] = TypeDef(defn.name.value, frozenset())
+    return out
+
+
+def diff_types(old: dict[str, TypeDef], new: dict[str, TypeDef]) -> list[Impact]:
+    """Compute impacts between two sets of GraphQL types.
+
+    Args:
+        old: Type definitions from the base reference.
+        new: Type definitions from the head reference.
+
+    Returns:
+        List of public API impacts between the two schemas.
+    """
+
+    impacts: list[Impact] = []
+
+    for name in old.keys() - new.keys():
+        impacts.append(Impact("major", name, "Removed type"))
+    for name in new.keys() - old.keys():
+        impacts.append(Impact("minor", name, "Added type"))
+    for name in old.keys() & new.keys():
+        op = old[name].fields
+        np = new[name].fields
+        for field in op - np:
+            impacts.append(Impact("major", f"{name}.{field}", "Removed field"))
+        for field in np - op:
+            impacts.append(Impact("minor", f"{name}.{field}", "Added field"))
+    return impacts
+
+
+def _run(cmd: list[str], cwd: str | None = None) -> str:
+    res = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return res.stdout
+
+
+def _list_graphql_files_at_ref(
+    ref: str, roots: Iterable[str], ignore_globs: Iterable[str], cwd: str | None = None
+) -> set[str]:
+    """List ``.graphql`` files under given roots at ``ref``."""
+
+    out = _run(["git", "ls-tree", "-r", "--name-only", ref], cwd)
+    paths: set[str] = set()
+    roots_norm = [str(Path(r)) for r in roots]
+    for line in out.splitlines():
+        if not line.endswith(".graphql"):
+            continue
+        p = Path(line)
+        if any(
+            str(p).startswith(r.rstrip("/") + "/") or str(p) == r for r in roots_norm
+        ):
+            s = str(p)
+            if ignore_globs and any(fnmatch(s, pat) for pat in ignore_globs):
+                continue
+            paths.add(s)
+    return paths
+
+
+def _build_schema_at_ref(
+    ref: str, roots: Iterable[str], ignores: Iterable[str], cwd: str | None = None
+) -> dict[str, TypeDef]:
+    """Collect type definitions from ``.graphql`` files at a git ref."""
+
+    paths = _list_graphql_files_at_ref(ref, roots, ignores, cwd)
+    contents = read_files_at_ref(ref, paths, cwd)
+    out: dict[str, TypeDef] = {}
+    for content in contents.values():
+        if content is None:
+            continue
+        out.update(extract_types_from_schema(content))
+    return out
+
+
+@register("graphql", "Analyze GraphQL schema changes.")
+class GraphQLAnalyser:
+    """Analyser plugin for GraphQL schemas."""
+
+    def __init__(self, cfg: Config) -> None:
+        """Initialize the analyser with configuration."""
+
+        self.cfg = cfg
+
+    def collect(self, ref: str) -> dict[str, TypeDef]:
+        """Collect GraphQL types at the given ref."""
+
+        return _build_schema_at_ref(
+            ref, self.cfg.project.public_roots, self.cfg.ignore.paths
+        )
+
+    def compare(self, old: dict[str, TypeDef], new: dict[str, TypeDef]) -> list[Impact]:
+        """Compare two schema states and return impacts."""
+
+        return diff_types(old, new)

--- a/docs/analysers/graphql.rst
+++ b/docs/analysers/graphql.rst
@@ -1,0 +1,43 @@
+GraphQL Analyser
+================
+
+Detects changes in GraphQL schema definitions.
+
+Dependencies
+~~~~~~~~~~~~
+
+* ``graphql-core``
+
+Enable or disable
+~~~~~~~~~~~~~~~~~
+
+Set ``graphql`` under ``[analysers]``.
+
+.. code-block:: toml
+
+   [analysers]
+   graphql = true  # set to false to disable
+
+Severity rules
+~~~~~~~~~~~~~~
+
+* Added type → minor
+* Removed type → major
+* Added field → minor
+* Removed field → major
+
+Detectable change
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: diff
+
+   @@
+-  type User { id: ID! }
++  type User { id: ID!, email: String }
+
+Example output
+~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   - [MINOR] User.email: Added field 'email'

--- a/docs/analysers/index.rst
+++ b/docs/analysers/index.rst
@@ -1,8 +1,8 @@
 Additional Analysers
 ====================
 
-The CLI, web route and migration analysers are **opt-in** and disabled by
-default. Enable them in ``bumpwright.toml``:
+The CLI, web route, GraphQL and migration analysers are **opt-in** and
+disabled by default. Enable them in ``bumpwright.toml``:
 
 .. code-block:: toml
 
@@ -10,6 +10,7 @@ default. Enable them in ``bumpwright.toml``:
    cli = true        # enable CLI analysis
    web_routes = true # enable web route analysis
    migrations = true # enable migrations analysis
+   graphql = true    # enable GraphQL analysis
 
    [migrations]
    paths = ["migrations"]  # directories with Alembic scripts
@@ -23,3 +24,4 @@ You can also toggle analysers per invocation with the command-line flags
    cli
    web_routes
    migrations
+   graphql

--- a/tests/test_graphql_analyser.py
+++ b/tests/test_graphql_analyser.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from bumpwright.analysers.graphql import (
+    TypeDef,
+    diff_types,
+    extract_types_from_schema,
+)
+
+
+def _build(sdl: str) -> dict[str, TypeDef]:
+    """Parse SDL into type definitions."""
+
+    return extract_types_from_schema(sdl)
+
+
+def test_removed_type_is_major() -> None:
+    """Removing a type should trigger a major impact."""
+
+    old = _build("type User { id: ID! }")
+    new: dict[str, TypeDef] = {}
+    impacts = diff_types(old, new)
+    assert any(i.severity == "major" and i.symbol == "User" for i in impacts)
+
+
+def test_added_type_is_minor() -> None:
+    """Adding a type should trigger a minor impact."""
+
+    old: dict[str, TypeDef] = {}
+    new = _build("type User { id: ID! }")
+    impacts = diff_types(old, new)
+    assert any(i.severity == "minor" and i.symbol == "User" for i in impacts)
+
+
+def test_added_field_is_minor() -> None:
+    """Adding a field is a minor change."""
+
+    old = _build("type User { id: ID! }")
+    new = _build("type User { id: ID!, name: String }")
+    impacts = diff_types(old, new)
+    assert any(i.severity == "minor" and i.symbol == "User.name" for i in impacts)
+
+
+def test_removed_field_is_major() -> None:
+    """Removing a field is a major change."""
+
+    old = _build("type User { id: ID!, name: String }")
+    new = _build("type User { id: ID! }")
+    impacts = diff_types(old, new)
+    assert any(i.severity == "major" and i.symbol == "User.name" for i in impacts)


### PR DESCRIPTION
## Summary
- track GraphQL schema changes to flag added or removed types and fields
- document analyser enablement and severity rules
- test GraphQL analyser for breaking and non-breaking changes

## Testing
- `ruff check bumpwright tests --fix`
- `isort bumpwright/analysers/graphql.py tests/test_graphql_analyser.py`
- `black bumpwright/analysers/graphql.py bumpwright/analysers/__init__.py tests/test_graphql_analyser.py`
- `pytest`

Labels: feat

------
https://chatgpt.com/codex/tasks/task_e_68a0cbe491a88322b9004455819325e4