### PR TITLE
feat(openapi): add OpenAPI analyser

### DIFF
--- a/bumpwright/analysers/__init__.py
+++ b/bumpwright/analysers/__init__.py
@@ -103,7 +103,7 @@ def get_analyser_info(name: str) -> AnalyserInfo | None:
 # Import built-in analysers for registration side-effects
 # isort: off
 # fmt: off
-from . import cli, migrations, web_routes  # noqa: F401,E402  # pylint: disable=wrong-import-position
+from . import cli, migrations, openapi, web_routes  # noqa: F401,E402  # pylint: disable=wrong-import-position
 # fmt: on
 # isort: on
 

--- a/bumpwright/analysers/openapi.py
+++ b/bumpwright/analysers/openapi.py
@@ -1,0 +1,117 @@
+"""OpenAPI specification analyser.
+
+Parses OpenAPI YAML or JSON documents to detect endpoint and schema changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..compare import Impact
+from ..config import Config
+from ..gitutils import read_files_at_ref
+from . import register
+
+
+@dataclass(frozen=True)
+class Spec:
+    """Collected data from an OpenAPI specification.
+
+    Attributes:
+        endpoints: Set of ``(path, method)`` tuples for all operations.
+        schemas: Mapping of component schema names to their definitions.
+    """
+
+    endpoints: set[tuple[str, str]]
+    schemas: dict[str, Any]
+
+
+def _parse_spec(content: str) -> Spec:
+    """Parse an OpenAPI document string.
+
+    Args:
+        content: YAML or JSON formatted OpenAPI document.
+
+    Returns:
+        Parsed :class:`Spec` containing endpoints and schema definitions.
+    """
+
+    data = yaml.safe_load(content) or {}
+    paths: dict[str, dict[str, Any]] = data.get("paths", {})
+    endpoints: set[tuple[str, str]] = set()
+    for path, methods in paths.items():
+        for method in methods:
+            endpoints.add((path, method.upper()))
+    schemas = data.get("components", {}).get("schemas", {})
+    return Spec(endpoints=endpoints, schemas=schemas)
+
+
+def diff_specs(old: Spec, new: Spec) -> list[Impact]:
+    """Compare two specs and return API impacts.
+
+    Args:
+        old: Specification from the base reference.
+        new: Specification from the head reference.
+
+    Returns:
+        List of :class:`Impact` entries describing differences.
+    """
+
+    impacts: list[Impact] = []
+    for ep in old.endpoints - new.endpoints:
+        impacts.append(Impact("major", f"{ep[1]} {ep[0]}", "Removed endpoint"))
+    for ep in new.endpoints - old.endpoints:
+        impacts.append(Impact("minor", f"{ep[1]} {ep[0]}", "Added endpoint"))
+    for name in old.schemas.keys() - new.schemas.keys():
+        impacts.append(Impact("major", name, "Removed schema"))
+    for name in new.schemas.keys() - old.schemas.keys():
+        impacts.append(Impact("minor", name, "Added schema"))
+    for name in old.schemas.keys() & new.schemas.keys():
+        if old.schemas[name] != new.schemas[name]:
+            impacts.append(Impact("major", name, "Changed schema"))
+    return impacts
+
+
+@register("openapi", "Analyze OpenAPI specs for API changes.")
+class OpenAPIAnalyser:
+    """Analyser plugin for OpenAPI specification files."""
+
+    def __init__(self, cfg: Config) -> None:
+        """Initialize the analyser with configuration.
+
+        Args:
+            cfg: Global configuration object.
+        """
+
+        self.cfg = cfg
+
+    def collect(self, ref: str) -> Spec:
+        """Collect OpenAPI spec data at ``ref``.
+
+        Args:
+            ref: Git reference to read from.
+
+        Returns:
+            Combined specification data from all configured paths.
+        """
+
+        paths = [str(Path(p)) for p in self.cfg.openapi.paths]
+        contents = read_files_at_ref(ref, paths)
+        endpoints: set[tuple[str, str]] = set()
+        schemas: dict[str, Any] = {}
+        for content in contents.values():
+            if content is None:
+                continue
+            spec = _parse_spec(content)
+            endpoints |= spec.endpoints
+            schemas.update(spec.schemas)
+        return Spec(endpoints=endpoints, schemas=schemas)
+
+    def compare(self, old: Spec, new: Spec) -> list[Impact]:
+        """Compare two collected specs and report impacts."""
+
+        return diff_specs(old, new)

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -77,6 +77,23 @@ class Migrations:
 
 
 @dataclass
+class OpenAPI:
+    """Settings for the OpenAPI analyser.
+
+    Attributes:
+        paths: File paths to OpenAPI specification documents.
+    """
+
+    paths: list[str] = field(
+        default_factory=lambda: [
+            "openapi.yaml",
+            "openapi.yml",
+            "openapi.json",
+        ]
+    )
+
+
+@dataclass
 class Changelog:
     """Changelog file configuration.
 
@@ -144,6 +161,7 @@ class Config:
     ignore: Ignore = field(default_factory=Ignore)
     analysers: Analysers = field(default_factory=Analysers)
     migrations: Migrations = field(default_factory=Migrations)
+    openapi: OpenAPI = field(default_factory=OpenAPI)
     changelog: Changelog = field(default_factory=Changelog)
     version: VersionFiles = field(default_factory=VersionFiles)
 
@@ -219,6 +237,7 @@ def load_config(path: str | Path = "bumpwright.toml") -> Config:
     enabled = {name for name, enabled in d["analysers"].items() if enabled}
     analysers = Analysers(enabled=enabled)
     migrations = Migrations(**d.get("migrations", {}))
+    openapi = OpenAPI(**d.get("openapi", {}))
     changelog = Changelog(**d.get("changelog", {}))
     version = VersionFiles(**d.get("version", {}))
     return Config(
@@ -227,6 +246,7 @@ def load_config(path: str | Path = "bumpwright.toml") -> Config:
         ignore=ign,
         analysers=analysers,
         migrations=migrations,
+        openapi=openapi,
         changelog=changelog,
         version=version,
     )

--- a/docs/analysers/index.rst
+++ b/docs/analysers/index.rst
@@ -1,8 +1,8 @@
 Additional Analysers
 ====================
 
-The CLI, web route and migration analysers are **opt-in** and disabled by
-default. Enable them in ``bumpwright.toml``:
+The CLI, web route, migration and OpenAPI analysers are **opt-in** and disabled
+by default. Enable them in ``bumpwright.toml``:
 
 .. code-block:: toml
 
@@ -10,9 +10,13 @@ default. Enable them in ``bumpwright.toml``:
    cli = true        # enable CLI analysis
    web_routes = true # enable web route analysis
    migrations = true # enable migrations analysis
+   openapi = true    # enable OpenAPI analysis
 
    [migrations]
    paths = ["migrations"]  # directories with Alembic scripts
+
+   [openapi]
+   paths = ["openapi.yaml"]
 
 You can also toggle analysers per invocation with the command-line flags
 ``--enable-analyser`` and ``--disable-analyser``.
@@ -23,3 +27,4 @@ You can also toggle analysers per invocation with the command-line flags
    cli
    web_routes
    migrations
+   openapi

--- a/docs/analysers/openapi.rst
+++ b/docs/analysers/openapi.rst
@@ -1,0 +1,49 @@
+OpenAPI Analyser
+================
+
+Detects changes in OpenAPI specification files.
+
+Dependencies
+~~~~~~~~~~~~
+
+* ``PyYAML``
+
+Enable or disable
+~~~~~~~~~~~~~~~~~
+
+Enable the analyser and specify spec paths in ``bumpwright.toml``.
+
+.. code-block:: toml
+
+   [analysers]
+   openapi = true
+
+   [openapi]
+   paths = ["openapi.yaml"]
+
+Severity rules
+~~~~~~~~~~~~~~
+
+* Added endpoint → minor
+* Removed endpoint → major
+* Added schema → minor
+* Removed schema → major
+* Changed schema definition → major
+
+Detectable change
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: diff
+
+   @@
+   paths:
+     /pets:
+-      get: {}
++      post: {}
+
+Example output
+~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   - [MAJOR] GET /pets: Removed endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "packaging>=24.0",
   "tomli>=1.0.0",
   "jinja2>=3.1",
+  "pyyaml>=6.0",
 ]
 
 classifiers = [

--- a/tests/test_openapi_analyser.py
+++ b/tests/test_openapi_analyser.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from bumpwright.analysers.openapi import Spec, _parse_spec, diff_specs
+
+
+def _build(src: str) -> Spec:
+    """Parse a spec snippet into a :class:`Spec`."""
+
+    return _parse_spec(src)
+
+
+def test_removed_endpoint_is_major() -> None:
+    """Removing an endpoint triggers a major impact."""
+
+    old = _build(
+        """
+openapi: 3.0.0
+paths:
+  /pets:
+    get: {}
+""",
+    )
+    new = _build(
+        """
+openapi: 3.0.0
+paths: {}
+""",
+    )
+    impacts = diff_specs(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_added_endpoint_is_minor() -> None:
+    """Adding a new endpoint triggers a minor impact."""
+
+    old = _build(
+        """
+openapi: 3.0.0
+paths: {}
+""",
+    )
+    new = _build(
+        """
+openapi: 3.0.0
+paths:
+  /pets:
+    post: {}
+""",
+    )
+    impacts = diff_specs(old, new)
+    assert any(i.severity == "minor" for i in impacts)
+
+
+def test_schema_change_is_major() -> None:
+    """Modifying a schema definition is a major impact."""
+
+    old = _build(
+        """
+openapi: 3.0.0
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+""",
+    )
+    new = _build(
+        """
+openapi: 3.0.0
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+""",
+    )
+    impacts = diff_specs(old, new)
+    assert any(i.severity == "major" and i.symbol == "Pet" for i in impacts)


### PR DESCRIPTION
## Summary
- add analyser to detect OpenAPI endpoint and schema changes
- expose OpenAPI paths in configuration
- document OpenAPI analyser usage

## Testing
- `ruff check .`
- `isort .`
- `black bumpwright/analysers/__init__.py bumpwright/analysers/openapi.py bumpwright/config.py tests/test_openapi_analyser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cbe5604483229ce4f3845588af72