### PR TITLE
docs(guides): reorganize and expand how-to guides

### DIFF
--- a/docs/guides/customization.rst
+++ b/docs/guides/customization.rst
@@ -1,23 +1,26 @@
-Advanced Usage
-==============
+Configuration examples
+======================
 
-Customise bumpwright beyond the basics.
+Adjust Bumpwright for complex projects using the examples below.
 
-Customise rules for version decisions:
+Custom version rules
+--------------------
 
 .. code-block:: toml
 
    [rules]
    return_type_change = "major"
 
-Exclude paths from API scanning:
+Ignore paths
+------------
 
 .. code-block:: toml
 
    [ignore]
    paths = ["tests/**", "examples/**"]
 
-Specify additional version file locations:
+Version file locations
+----------------------
 
 .. code-block:: toml
 
@@ -26,13 +29,11 @@ Specify additional version file locations:
    ignore = ["examples/**"]
    scheme = "semver"
 
-Apply a bump and commit/tag automatically:
+Automatic bump with commit and tag
+----------------------------------
 
 .. code-block:: console
 
    bumpwright bump --base v1.0.0 --head HEAD --commit --tag
 
-.. toctree::
-   :maxdepth: 1
-
-   monorepos
+Need to support multiple packages? See :doc:`monorepos`.

--- a/docs/guides/github-actions.rst
+++ b/docs/guides/github-actions.rst
@@ -1,10 +1,14 @@
 GitHub Actions workflows
 ========================
 
-Bumpwright integrates easily with GitHub Actions. The workflows below show
-how to automatically apply a version bump on pushes to your main branch,
-suggest the next semantic version, and run a manual release. Place these files
-in the ``.github/workflows`` directory of your project to use them.
+Bumpwright integrates easily with GitHub Actions. This guide covers three
+workflows:
+
+* Automatically apply a version bump on pushes to your main branch.
+* Suggest the next semantic version in pull requests.
+* Run a manual release with tagging.
+
+Place the selected file in ``.github/workflows`` to use it.
 
 Workflows that create commits or tags require ``permissions: contents: write``
 and authenticate using the default ``GITHUB_TOKEN``. When referencing the

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -1,10 +1,16 @@
-Guides
-======
+How-to guides
+=============
 
-Practical guides for using bumpwright in complex scenarios.
+Step-by-step recipes for using Bumpwright in real projects.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :titlesonly:
 
-   advanced/index
-   workflows
+   customization
+   monorepos
+   github-actions
+
+* :doc:`customization` – tweak rules, ignored paths, and version files.
+* :doc:`monorepos` – handle projects with multiple packages.
+* :doc:`github-actions` – integrate Bumpwright into GitHub Actions.

--- a/docs/guides/monorepos.rst
+++ b/docs/guides/monorepos.rst
@@ -1,7 +1,13 @@
 Handling multi-package repositories
 ===================================
 
-1. Configure version file paths for each package in ``bumpwright.toml``:
+Bumpwright works in monorepos with several packages by targeting each package
+independently.
+
+Configure version file paths
+----------------------------
+
+Define where versions are stored for each package in ``bumpwright.toml``:
 
 .. code-block:: toml
 
@@ -12,7 +18,10 @@ Handling multi-package repositories
    ]
    scheme = "semver"
 
-2. Run ``bumpwright`` for the package that changed:
+Run Bumpwright for the changed package
+--------------------------------------
+
+Invoke Bumpwright against the package that changed:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Summary
- reorganize guides into clearer how-to structure
- add dedicated pages for customization, GitHub Actions workflows, and monorepos

## Testing
- `ruff check .`
- `black docs/guides`
- `isort .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cca3995c83229beb3247158e8399