### PR TITLE
feat(public-api): allow configuring private symbol prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ all sections and their default values looks like:
 [project]
 package = ""
 public_roots = ["."]
+private_prefixes = ["_"]
 
 [ignore]
 paths = ["tests/**", "examples/**", "scripts/**"]
@@ -193,7 +194,7 @@ ignore = ["build/**", "dist/**", "*.egg-info/**", ".eggs/**", ".venv/**", "venv/
 Set an analyser to ``true`` to enable it. Each section configures a different
 aspect of bumpwright:
 
-- **project** – identifies the package, public API roots, and metadata file.
+- **project** – identifies the package, public API roots, private symbol prefixes, and metadata file.
 - **ignore** – glob patterns excluded from analysis. These defaults skip common build artifacts and virtual environments such as `build/**`, `dist/**`, `*.egg-info/**`, `.eggs/**`, `.venv/**`, `venv/**`, `.env/**`, and `**/__pycache__/**`.
 - **rules** – maps findings to semantic version levels.
 - **[analysers]** – toggles built-in or plugin analysers.
@@ -202,6 +203,10 @@ aspect of bumpwright:
   ``template`` selects a custom Jinja2 template (leave empty for the built-in
   version).
 - **version** – files where version strings are read and updated.
+
+Symbols beginning with any prefix listed in ``private_prefixes`` are excluded
+from public API analysis, preventing internal helpers from triggering
+unnecessary version bumps.
 
 See ``docs/configuration.rst`` for in-depth descriptions and additional
 examples. The default file name is ``bumpwright.toml`` but you may specify an

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -43,10 +43,12 @@ class Project:
         package: Importable package containing the project's code. When empty the
             repository layout is used.
         public_roots: Paths whose contents constitute the public API.
+        private_prefixes: Symbol name prefixes treated as private.
     """
 
     package: str = ""
     public_roots: list[str] = field(default_factory=lambda: ["."])
+    private_prefixes: list[str] = field(default_factory=lambda: ["_"])
 
 
 @dataclass

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,6 +12,7 @@ Example configuration showing all available sections and their default values:
     [project]
     package = ""
     public_roots = ["."]
+    private_prefixes = ["_"]
 
     [ignore]
     paths = ["tests/**", "examples/**", "scripts/**"]
@@ -61,6 +62,14 @@ Project
      - list[str]
      - ``["."]``
      - Paths whose contents constitute the public API.
+   * - ``private_prefixes``
+     - list[str]
+     - ``["_"]``
+     - Symbol prefixes treated as private and ignored during API analysis.
+
+Symbols beginning with any of the values in ``private_prefixes`` are excluded
+from public API comparisons, allowing helper functions to avoid triggering
+version bumps.
 
 Ignore
 ~~~~~~

--- a/tests/test_cli_ignore.py
+++ b/tests/test_cli_ignore.py
@@ -30,7 +30,7 @@ def test_build_api_respects_ignores(tmp_path: Path) -> None:
     old_cwd = os.getcwd()
     os.chdir(repo)
     try:
-        api = _build_api_at_ref(ref, ["pkg"], ["pkg/ignored.py"])
+        api = _build_api_at_ref(ref, ["pkg"], ["pkg/ignored.py"], ["_"])
     finally:
         os.chdir(old_cwd)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,18 @@ def test_load_config_defaults_analysers(tmp_path: Path) -> None:
     assert cfg.analysers.enabled == set()
 
 
+def test_load_config_private_prefixes(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "bumpwright.toml"
+    cfg_file.write_text("[project]\nprivate_prefixes=['__', 'internal_']\n")
+    cfg = load_config(cfg_file)
+    assert cfg.project.private_prefixes == ["__", "internal_"]
+
+
+def test_load_config_private_prefixes_default(tmp_path: Path) -> None:
+    cfg = load_config(tmp_path / "missing.toml")
+    assert cfg.project.private_prefixes == ["_"]
+
+
 def test_load_config_changelog(tmp_path: Path) -> None:
     cfg_file = tmp_path / "bumpwright.toml"
     cfg_file.write_text("[changelog]\npath='NEWS.md'\ntemplate='tmpl.j2'\n")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -129,3 +129,15 @@ def bar():
     api = extract_public_api_from_source("pkg.mod", code)
     keys = set(api.keys())
     assert {"pkg.mod:foo", "pkg.mod:bar"} == keys
+
+
+def test_custom_private_prefix() -> None:
+    code = """
+def internal_func():
+    pass
+def public():
+    pass
+"""
+    api = extract_public_api_from_source("pkg.mod", code, ["internal_"])
+    assert "pkg.mod:public" in api
+    assert "pkg.mod:internal_func" not in api


### PR DESCRIPTION
## Summary
- allow configuration of private symbol prefixes to exclude from public API analysis
- honor configured prefixes in CLI and API extraction
- document `private_prefixes` usage in README and docs

## Testing
- `ruff check --fix .`
- `isort tests/test_cli_ignore.py`
- `black tests/test_cli_ignore.py`
- `pytest`

## Labels
- feat

------
https://chatgpt.com/codex/tasks/task_e_68a0cda9ac648322808a6c54afe0f784