### PR TITLE
docs(troubleshooting): clarify changelog template option

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -46,10 +46,10 @@ before running Bumpwright.
 
 Template path not found
 ~~~~~~~~~~~~~~~~~~~~~~~
-*Cause*: The template file referenced by ``--template`` cannot be located.
+*Cause*: The Jinja2 template used for release notes, referenced by ``--changelog-template``, cannot be located.
 
-*Fix*: Provide the full path to an existing template or add it to the expected
-location so Bumpwright can render the changelog.
+*Fix*: Provide the full path to an existing Jinja2 template or add it to the expected
+location so Bumpwright can render the release notes.
 
 FAQ
 ---


### PR DESCRIPTION
## Summary
- clarify that `--changelog-template` selects the Jinja2 template used for release notes in troubleshooting docs

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat tests/test_gitutils.py)*
- `isort . --check-only`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_68a0d0155c0c8322890c71da3b3672d0