### PR TITLE
feat(versioning): add cache clearing helper

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -13,3 +13,9 @@ Measured on CPython 3.12 using ``time.perf_counter``. Subsequent calls reuse
 cached results, dramatically reducing overhead when applying multiple bumps in
 one process.
 
+In scenarios where versioned files may be created or removed dynamically,
+invoke ``bumpwright.versioning.clear_version_file_cache()`` to drop cached
+results before the next bump. The cache is also cleared automatically whenever
+``apply_bump`` is called with different ``paths`` or ``ignore`` patterns from
+the previous invocation.
+

--- a/docs/usage/bump.rst
+++ b/docs/usage/bump.rst
@@ -192,3 +192,6 @@ Common errors
 
 Changes not applied after running
     The ``--dry-run`` flag previews the bump without touching files. Remove it and, if desired, add ``--commit`` and ``--tag`` to persist the change.
+
+Versioned files created or removed
+    Call ``bumpwright.versioning.clear_version_file_cache()`` before the next run or change ``--version-path``/``--version-ignore`` patterns so ``bumpwright`` rescans the filesystem.


### PR DESCRIPTION
## Summary
- expose `clear_version_file_cache` to reset cached version file paths
- automatically drop cache when `apply_bump` receives different `paths` or `ignore`
- document cache clearing for dynamic file layouts

## Testing
- `python -m isort bumpwright tests`
- `python -m black bumpwright/versioning.py tests/test_versioning.py`
- `python -m ruff check bumpwright/versioning.py tests/test_versioning.py`
- `pytest`

Labels: feat


------
https://chatgpt.com/codex/tasks/task_e_68a0d44390c88322998ac10b26379b2d