### PR TITLE
feat(changelog): add commit exclusion patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ paths = ["migrations"]
 [changelog]
 path = ""
 template = ""
+exclude = []
 
 [version]
 paths = ["pyproject.toml", "setup.py", "setup.cfg", "**/__init__.py", "**/version.py", "**/_version.py"]
@@ -208,7 +209,7 @@ aspect of bumpwright:
 - **migrations** – directories containing Alembic migration scripts.
 - **changelog** – default changelog file used with ``--changelog``.
   ``template`` selects a custom Jinja2 template (leave empty for the built-in
-  version).
+  version) and ``exclude`` lists regex patterns for commit subjects to skip.
 - **version** – files where version strings are read and updated.
 
 Symbols beginning with any prefix listed in ``private_prefixes`` are excluded

--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -154,6 +154,14 @@ def get_parser() -> argparse.ArgumentParser:
         "--changelog-template",
         help="Jinja2 template file for changelog entries; defaults to built-in template.",
     )
+    p_bump.add_argument(
+        "--changelog-exclude",
+        action="append",
+        help=(
+            "Regex pattern for commit subjects to exclude from changelog "
+            "(repeatable)."
+        ),
+    )
     p_bump.set_defaults(func=bump_command)
     return parser
 

--- a/bumpwright/config.py
+++ b/bumpwright/config.py
@@ -103,10 +103,13 @@ class Changelog:
         path: Default changelog file path. Empty string disables changelog generation.
         template: Jinja2 template file for changelog entries. Empty string selects
             the built-in template.
+        exclude: Regular expression patterns for commit subjects to omit from
+            changelog entries.
     """
 
     path: str = ""
     template: str = ""
+    exclude: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -131,6 +131,13 @@ def init(args: argparse.Namespace) -> int:
     type=str,
     help=("Jinja2 template file for changelog entries; defaults to built-in template."),
 )
+@click.option(
+    "--changelog-exclude",
+    multiple=True,
+    help=(
+        "Regex pattern for commit subjects to exclude from changelog " "(repeatable)."
+    ),
+)
 @click.pass_obj
 def bump(args: argparse.Namespace, **kwargs: object) -> int:
     """Update version metadata and optionally commit and tag the change.
@@ -188,6 +195,9 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
             changelog_template (str | None): Path to a Jinja2 template used to
             render changelog entries. Defaults to the built-in template.
 
+            changelog_exclude (tuple[str, ...]): Regex patterns of commit
+            subjects to omit from changelog entries.
+
     Returns:
         Exit status code, where ``0`` indicates success and ``1`` an error.
     """
@@ -198,5 +208,6 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
     params["disable_analyser"] = list(params.get("disable_analyser", []))
     params["version_path"] = list(params.get("version_path", []))
     params["version_ignore"] = list(params.get("version_ignore", []))
+    params["changelog_exclude"] = list(params.get("changelog_exclude", []))
     params["format"] = params.pop("format_")
     return bump_command(argparse.Namespace(**params))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -238,6 +238,10 @@ Changelog
      - ``""``
      - Jinja2 template file for changelog entries. Empty string selects the
        built-in template.
+   * - ``exclude``
+     - list[str]
+     - ``[]``
+     - Regex patterns for commit subjects to omit from changelog entries.
 
 All sections and keys are optional; unspecified values fall back to the
 defaults shown above.

--- a/docs/usage/bump.rst
+++ b/docs/usage/bump.rst
@@ -77,6 +77,9 @@ Arguments
 ``--changelog-template PATH``
     Jinja2 template file used when rendering changelog entries. Defaults to the built-in template or ``[changelog].template`` when configured. Useful for customising changelog layout.
 
+``--changelog-exclude REGEX``
+    Regex pattern for commit subjects to exclude from changelog entries. Repeatable. Patterns from configuration are combined with CLI values.
+
 ``--pyproject PATH``
     Path to the project's ``pyproject.toml`` file. Defaults to ``pyproject.toml``.
 

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -148,6 +148,24 @@ def test_build_changelog_uses_read_template(monkeypatch) -> None:
     assert result == "Version=0.2.0\n"
 
 
+def test_build_changelog_excludes_patterns(monkeypatch) -> None:
+    args = argparse.Namespace(
+        changelog="CHANGELOG.md",
+        head="HEAD",
+        repo_url=None,
+        changelog_template=None,
+        changelog_exclude=["^chore"],
+    )
+    commits = [("1", "feat: add"), ("2", "chore: skip")]
+    monkeypatch.setattr(
+        "bumpwright.cli.bump.collect_commits", lambda base, head: commits
+    )
+    monkeypatch.setattr("bumpwright.cli.bump.last_release_commit", lambda: None)
+    result = _build_changelog(args, "0.2.0")
+    assert "feat: add" in result
+    assert "chore: skip" not in result
+
+
 def test_commit_tag_existing_tag(tmp_path: Path) -> None:
     repo, _, _ = setup_repo(tmp_path)
     pyproj = repo / "pyproject.toml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,16 +38,20 @@ def test_load_config_private_prefixes_default(tmp_path: Path) -> None:
 
 def test_load_config_changelog(tmp_path: Path) -> None:
     cfg_file = tmp_path / "bumpwright.toml"
-    cfg_file.write_text("[changelog]\npath='NEWS.md'\ntemplate='tmpl.j2'\n")
+    cfg_file.write_text(
+        "[changelog]\npath='NEWS.md'\ntemplate='tmpl.j2'\nexclude=['^chore']\n"
+    )
     cfg = load_config(cfg_file)
     assert cfg.changelog.path == "NEWS.md"
     assert cfg.changelog.template == "tmpl.j2"
+    assert cfg.changelog.exclude == ["^chore"]
 
 
 def test_load_config_changelog_default(tmp_path: Path) -> None:
     cfg = load_config(tmp_path / "missing.toml")
     assert cfg.changelog.path == ""
     assert cfg.changelog.template == ""
+    assert cfg.changelog.exclude == []
 
 
 def test_load_config_default_scheme(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `--changelog-exclude` option and configuration
- filter changelog commits by exclusion patterns
- document and test changelog exclusions

## Testing
- `isort tests/test_cli_changelog.py tests/test_cli_bump_helpers.py tests/test_config.py bumpwright/cli/bump.py bumpwright/cli/__init__.py bumpwright/config.py docs/_bumpwright_click.py docs/configuration.rst docs/usage/bump.rst README.md`
- `black tests/test_cli_changelog.py tests/test_cli_bump_helpers.py tests/test_config.py bumpwright/cli/bump.py bumpwright/cli/__init__.py bumpwright/config.py docs/_bumpwright_click.py`
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d45bcec88322ad25eba2288e4b02