### PR TITLE
fix(cli): warn when git diff fails to compute changed paths

### DIFF
--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -121,11 +121,20 @@ def _resolve_refs(args: argparse.Namespace, level: str | None) -> tuple[str, str
 
 
 def _safe_changed_paths(base: str, head: str) -> set[str] | None:
-    """Return changed paths, handling missing history gracefully."""
+    """Return changed paths, handling missing history gracefully.
+
+    Args:
+        base: Base git reference for comparison.
+        head: Head git reference for comparison.
+
+    Returns:
+        A set of changed paths or ``None`` when the diff cannot be determined.
+    """
 
     try:
         return changed_paths(base, head)
     except subprocess.CalledProcessError:
+        logger.warning("Failed to compute changed paths between %s and %s", base, head)
         return None
 
 

--- a/tests/test_cli_bump_format.py
+++ b/tests/test_cli_bump_format.py
@@ -32,7 +32,9 @@ def test_bump_command_json_format(tmp_path: Path) -> None:
         text=True,
         env=env,
     )
-    data = json.loads(res.stderr)
+    assert "Failed to compute changed paths" in res.stderr
+    json_str = res.stderr.split("\n", 1)[1]
+    data = json.loads(json_str)
     assert data["old_version"] == "0.1.0"
     assert data["new_version"] == "0.2.0"
     assert data["level"] == "minor"


### PR DESCRIPTION
## Summary
- log a warning when `git diff` cannot determine changed paths
- test warning handling in helper and JSON format output

## Testing
- `ruff check bumpwright/cli/bump.py tests/test_cli_bump_helpers.py tests/test_cli_bump_format.py`
- `isort --check-only -v tests/test_cli_bump_format.py`
- `black tests/test_cli_bump_format.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e15fd7c083229448db979733b9e0