### PR TITLE
docs(ci): add GitHub Actions examples and clarify badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Suggested bump: minor
 See the [documentation](docs/index.rst) for detailed guides and advanced
 scenarios.
 
+## Badges
+
+The badges above are generated with
+[`docs/scripts/generate_badges.py`](docs/scripts/generate_badges.py).
+Run it in CI after tests to reuse the existing coverage result:
+
+```bash
+python docs/scripts/generate_badges.py <coverage> <version> <license> <python_versions>
+```
+
+Publish the resulting SVGs to any static host such as GitHub Pages and update
+the badge URLs accordingly. Hosted services like [shields.io](https://shields.io)
+are viable alternatives.
+
 ## Development
 
 This project uses [pre-commit](https://pre-commit.com/) with Ruff, Black, and

--- a/docs/ci/github-actions.rst
+++ b/docs/ci/github-actions.rst
@@ -1,0 +1,77 @@
+GitHub Actions
+==============
+
+These minimal examples show how to integrate Bumpwright with
+GitHub Actions.  They avoid duplicating coverage jobs and can be
+adapted for other CI providers such as GitLab or Jenkins.
+
+Decide and apply on push
+------------------------
+
+Runs on pushes to ``main``.  The workflow decides the bump, applies it
+when the decision is at least a patch, creates a tag, and pushes it.
+
+.. code-block:: yaml
+
+   name: Bumpwright Decide and Apply
+   on:
+     push:
+       branches: [main]
+   jobs:
+     bump:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-python@v5
+           with:
+             python-version: '3.x'
+         - run: pip install bumpwright jq
+         - id: decision
+           run: |
+             bumpwright bump --decide --json > decision.json
+             echo "level=$(jq -r '.level' decision.json)" >> "$GITHUB_OUTPUT"
+         - name: apply bump
+           if: steps.decision.outputs.level != 'none'
+           run: |
+             bumpwright bump --apply --tag
+             git push --tags
+
+Decision only
+-------------
+
+Produces a JSON artifact for a manual gate or release job.
+
+.. code-block:: yaml
+
+   name: Bumpwright Decision
+   on: [push]
+   jobs:
+     decide:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-python@v5
+           with:
+             python-version: '3.x'
+         - run: pip install bumpwright
+         - run: bumpwright bump --decide --json > decision.json
+         - uses: actions/upload-artifact@v4
+           with:
+             name: bumpwright-decision
+             path: decision.json
+
+To feed the decision into a separate apply job, download the artifact and
+parse the level with ``jq``:
+
+.. code-block:: yaml
+
+   - uses: actions/download-artifact@v4
+     with:
+       name: bumpwright-decision
+   - run: |
+       level=$(jq -r '.level' decision.json)
+       if [ "$level" != "none" ]; then
+         bumpwright bump --apply --tag
+         git push --tags
+       fi
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,14 @@ Examples & Recipes
 
    recipes
 
+CI integration
+--------------
+
+.. toctree::
+   :maxdepth: 2
+
+   ci/github-actions
+
 Troubleshooting & FAQ
 ---------------------
 


### PR DESCRIPTION
## Summary
- add GitHub Actions decide-and-apply and decision-only examples
- document badge generation and hosting options

## Testing
- `ruff check .`
- `black --check --line-length 127 bumpwright tests`
- `isort --check-only bumpwright tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e554cb8c8322bc04cc822c7e43c9