### PR TITLE
docs(cli): align docs with CLI and add glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ bumpwright bump --decide
 bumpwright bump --commit --tag
 ```
 
+> **Note**
+> Omitting `--base` compares against the last release commit or the previous commit (`HEAD^`). Using `--commit` or `--tag` requires a clean working tree.
+
 Example output from `bumpwright bump --decide`:
 
 ```text

--- a/docs/ci/github-actions.rst
+++ b/docs/ci/github-actions.rst
@@ -33,7 +33,7 @@ when the decision is at least a patch, creates a tag, and pushes it.
          - name: apply bump
            if: steps.decision.outputs.level != 'none'
            run: |
-             bumpwright bump --apply --tag
+             bumpwright bump --commit --tag
              git push --tags
 
 Decision only
@@ -71,7 +71,7 @@ parse the level with ``jq``:
    - run: |
        level=$(jq -r '.level' decision.json)
        if [ "$level" != "none" ]; then
-         bumpwright bump --apply --tag
+         bumpwright bump --commit --tag
          git push --tags
        fi
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,28 @@
+Glossary
+========
+
+.. glossary::
+
+   public API
+       Symbols and behaviours considered part of the supported interface for consumers.
+
+   major
+       Version increment signalling incompatible changes.
+
+   minor
+       Version increment for backwards-compatible feature additions.
+
+   patch
+       Version increment for backwards-compatible bug fixes.
+
+   decision
+       The bump level and confidence derived from analysing API changes.
+
+   base/head
+       Git references used for comparison; ``base`` is the earlier commit and ``head`` the later.
+
+   analyser
+       Plugin that inspects a specific domain for API-impacting changes.
+
+   rule severity
+       Mapping from a detected change to the bump level it triggers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ Reference
 
    cli_reference
    analysers/index
+   glossary
 
 Examples & Recipes
 ------------------

--- a/docs/recipes/index.rst
+++ b/docs/recipes/index.rst
@@ -6,27 +6,18 @@ Monorepo or multi-package layout
 
 .. code-block:: bash
 
-   bumpwright bump --public-roots pkg_a src/pkg_b
+   bumpwright bump --pyproject packages/pkg_a/pyproject.toml
 
-Run analyses across multiple packages while keeping their APIs distinct.
+Analyse a single package in a monorepo while keeping other packages untouched.
 
-Pre-releases and tags
----------------------
-
-.. code-block:: bash
-
-   bumpwright bump --level prerelease --suffix rc
-
-Create release candidates without touching the stable version line.
-
-Ignoring paths / narrowing public roots
----------------------------------------
+Commit and tag
+--------------
 
 .. code-block:: bash
 
-   bumpwright bump --ignore tests/fixtures --public-roots src
+   bumpwright bump --level patch --commit --tag
 
-Exclude helper code and limit scanning to your public modules.
+Create a release commit and matching tag.
 
 Running locally vs CI
 ---------------------
@@ -42,7 +33,6 @@ JSON output + machine consumption
 
 .. code-block:: bash
 
-   bumpwright bump --format json | jq '.suggested'
+   bumpwright bump --format json | jq '.level'
 
 Pipe structured results into other tools or CI steps.
-

--- a/docs/usage/bump.rst
+++ b/docs/usage/bump.rst
@@ -98,6 +98,9 @@ Arguments
 ``--dry-run``
     Display the new version without modifying any files. Defaults to ``false``.
 
+.. note::
+   Omitting ``--base`` compares against the last release commit or ``HEAD^``. When ``--commit`` or ``--tag`` is used, the working tree must be clean.
+
 Examples
 --------
 


### PR DESCRIPTION
## Summary
- document default ref behaviour and clean working tree requirement
- replace outdated CLI examples and include a glossary
- ensure GitHub Actions and recipes use supported flags

## Testing
- ❌ `pre-commit run --files README.md docs/ci/github-actions.rst docs/index.rst docs/recipes/index.rst docs/usage/bump.rst docs/glossary.rst` *(config file missing)*
- ❌ `pytest` *(19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e7a16b148322be6fee1934a23d62