### PR TITLE
feat(changelog): enrich changelog context and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,35 @@ Suggested bump: minor
 See the [Quickstart guide](docs/quickstart.rst) for a full walk-through and the
 [documentation](docs/index.rst) for detailed guides.
 
+## Changelog generation
+
+Bumpwright can append release notes to a changelog using a Jinja2 template. The
+default context provides additional fields sourced from git:
+
+- ``release_datetime_iso`` – ISO-8601 timestamp of the tag's commit.
+- ``compare_url`` – GitHub compare link between the previous and new tags.
+- ``contributors`` – unique authors from ``git shortlog -sne`` linking to
+  profiles when ``users.noreply.github.com`` emails are detected.
+- ``breaking_changes`` – commits marked with a ``!`` type or a
+  ``BREAKING CHANGE:`` footer.
+
+Example output using the built-in template:
+
+```markdown
+## [v1.2.4] - 2024-04-01 (2024-04-01T12:00:00+00:00)
+[Diff since v1.2.3](https://github.com/me/project/compare/v1.2.3...v1.2.4)
+- [abc123](https://github.com/me/project/commit/abc123) feat!: drop old API
+
+### Breaking changes
+- feat!: drop old API
+
+### Contributors
+- [alice](https://github.com/alice)
+```
+
+Compare links let readers explore the full diff, while contributor names are
+auto-detected from the commit history.
+
 ## Badges
 
 The badges above are generated with

--- a/bumpwright/templates/changelog.md.j2
+++ b/bumpwright/templates/changelog.md.j2
@@ -1,4 +1,13 @@
-## [v{{ version }}] - {{ date }}
-{% for c in commits %}- {% if c.link %}[{{ c.sha }}]({{ c.link }}){% else %}{{ c.sha }}{% endif %} {{ c.subject }}
-{% endfor %}
+## [v{{ version }}] - {{ date }} ({{ release_datetime_iso }})
+{% if compare_url and previous_tag %}[Diff since {{ previous_tag }}]({{ compare_url }})
+{% endif %}{% for c in commits %}- {% if c.link %}[{{ c.sha }}]({{ c.link }}){% else %}{{ c.sha }}{% endif %} {{ c.subject }}
+{% endfor %}{% if breaking_changes %}
+
+### Breaking changes
+{% for bc in breaking_changes %}- {{ bc }}
+{% endfor %}{% endif %}{% if contributors %}
+
+### Contributors
+{% for p in contributors %}- {% if p.link %}[{{ p.name }}]({{ p.link }}){% else %}{{ p.name }}{% endif %}
+{% endfor %}{% endif %}
 

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -14,7 +14,9 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -48,7 +50,9 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
 def test_bump_writes_changelog(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -84,7 +88,9 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
 def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -119,7 +125,9 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
 def test_changelog_links_repo_url(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -157,7 +165,9 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     (repo / "tpl.j2").write_text("VERSION={{ version }}\n", encoding="utf-8")
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -195,7 +205,9 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -223,7 +235,9 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
 def test_changelog_exclude_cli(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "--allow-empty", "-m", "chore: drop"], repo)
     run(["git", "commit", "-am", "feat: keep"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -262,7 +276,9 @@ def test_changelog_exclude_config(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
     run(["git", "commit", "--allow-empty", "-m", "chore: drop"], repo)
     run(["git", "commit", "-am", "feat: keep"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -288,3 +304,90 @@ def test_changelog_exclude_config(tmp_path: Path) -> None:
     content = (repo / "CHANGELOG.md").read_text()
     assert "feat: keep" in content
     assert "chore: drop" not in content
+
+
+def test_changelog_diff_and_contributors(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    run(["git", "tag", "v0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(
+        [
+            "git",
+            "commit",
+            "-am",
+            "feat: change",
+            "--author",
+            "Alice <alice@users.noreply.github.com>",
+        ],
+        repo,
+    )
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+            "--changelog",
+            "CHANGELOG.md",
+            "--repo-url",
+            "https://github.com/me/project",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    content = (repo / "CHANGELOG.md").read_text()
+    compare_line = (
+        "[Diff since v0.1.0](https://github.com/me/project/compare/v0.1.0...v0.1.1)"
+    )
+    assert compare_line in content
+    assert "### Contributors" in content
+    assert "- [Alice](https://github.com/alice)" in content
+    assert "### Breaking changes" not in content
+
+
+def test_changelog_breaking_changes(tmp_path: Path) -> None:
+    repo, pkg, _ = setup_repo(tmp_path)
+    run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
+    run(["git", "tag", "v0.1.0"], repo)
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 2\n", encoding="utf-8"
+    )
+    run(["git", "commit", "-am", "feat!: break"], repo)
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bumpwright.cli",
+            "bump",
+            "--level",
+            "patch",
+            "--pyproject",
+            "pyproject.toml",
+            "--dry-run",
+            "--changelog",
+            "CHANGELOG.md",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    content = (repo / "CHANGELOG.md").read_text()
+    assert "### Breaking changes" in content
+    assert "feat!: break" in content


### PR DESCRIPTION
## Summary
- extend changelog context with release timestamp, compare URLs, contributors, and breaking change detection
- expand default changelog template and document new sections
- describe changelog context fields in README and usage docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec6460a88322a6e060e6a56c32c2