### PR TITLE
feat!(cli): remove level option from bump command

### DIFF
--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -61,7 +61,9 @@ def get_parser() -> argparse.ArgumentParser:
     avail = ", ".join(available()) or "none"
     parser = argparse.ArgumentParser(
         prog="bumpwright",
-        description=(f"Suggest and apply semantic version bumps. Available analysers: {avail}."),
+        description=(
+            f"Suggest and apply semantic version bumps. Available analysers: {avail}."
+        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -85,11 +87,6 @@ def get_parser() -> argparse.ArgumentParser:
         "bump",
         help="Apply a version bump",
         description="Update project version metadata and optionally commit and tag the change.",
-    )
-    p_bump.add_argument(
-        "--level",
-        choices=["major", "minor", "patch"],
-        help="Desired bump level; if omitted, it is inferred from --base and --head.",
     )
     add_ref_options(p_bump)
     p_bump.add_argument(
@@ -134,7 +131,9 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Create a git commit for the version change.",
     )
-    p_bump.add_argument("--tag", action="store_true", help="Create a git tag for the new version.")
+    p_bump.add_argument(
+        "--tag", action="store_true", help="Create a git tag for the new version."
+    )
     p_bump.add_argument(
         "--dry-run",
         action="store_true",
@@ -153,7 +152,9 @@ def get_parser() -> argparse.ArgumentParser:
     p_bump.add_argument(
         "--changelog-exclude",
         action="append",
-        help=("Regex pattern for commit subjects to exclude from changelog (repeatable)."),
+        help=(
+            "Regex pattern for commit subjects to exclude from changelog (repeatable)."
+        ),
     )
     p_bump.set_defaults(func=bump_command)
     return parser

--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -47,11 +47,6 @@ def init(args: argparse.Namespace) -> int:
 
 @cli.command()
 @click.option(
-    "--level",
-    type=click.Choice(["major", "minor", "patch"]),
-    help="Desired bump level; if omitted, it is inferred from --base and --head.",
-)
-@click.option(
     "--base",
     help=(
         "Base git reference when auto-deciding the level. Defaults to the last release "
@@ -145,10 +140,6 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
     Args:
         args: Parsed command-line arguments from :func:`cli`.
         **kwargs: Command-specific options. Notable parameters include:
-
-            level (str | None): Desired bump level, one of ``major``, ``minor``,
-            or ``patch``. If omitted the level is inferred from repository
-            history.
 
             base (str | None): Git reference used as the comparison base when
             inferring the bump level. Defaults to the latest release commit or

--- a/docs/_static/workflows/bumpwright-release.yml
+++ b/docs/_static/workflows/bumpwright-release.yml
@@ -2,15 +2,6 @@ name: bumpwright release
 
 on:
   workflow_dispatch:
-    inputs:
-      level:
-        description: 'Version bump level'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 jobs:
   bump:
@@ -28,7 +19,7 @@ jobs:
         run: pip install bumpwright
       - name: Apply version bump
         run: |
-          bumpwright bump --level ${{ github.event.inputs.level }} \  # level from workflow input
+          bumpwright bump \
             --pyproject pyproject.toml --commit --tag
       - name: Push changes
         run: git push origin HEAD --follow-tags

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -40,7 +40,7 @@ notes to ``CHANGELOG.md``:
 
 .. code-block:: console
 
-   $ bumpwright bump --level patch --repo-url https://github.com/me/project --changelog CHANGELOG.md
+   $ bumpwright bump --repo-url https://github.com/me/project --changelog CHANGELOG.md
    Bumped version: 0.1.0 -> 0.1.1 (patch)
    Updated files: pyproject.toml, CHANGELOG.md
 

--- a/docs/guides/monorepos.rst
+++ b/docs/guides/monorepos.rst
@@ -25,7 +25,7 @@ Invoke Bumpwright against the package that changed:
 
 .. code-block:: console
 
-   bumpwright bump --level minor --pyproject packages/pkg_a/pyproject.toml
+   bumpwright bump --pyproject packages/pkg_a/pyproject.toml
 
 .. code-block:: text
 

--- a/docs/recipes/index.rst
+++ b/docs/recipes/index.rst
@@ -15,7 +15,7 @@ Commit and tag
 
 .. code-block:: bash
 
-   bumpwright bump --level patch --commit --tag
+   bumpwright bump --commit --tag
 
 Create a release commit and matching tag.
 

--- a/docs/usage/bump.rst
+++ b/docs/usage/bump.rst
@@ -50,9 +50,6 @@ Update version information in ``pyproject.toml`` and other files. By default, ``
 Arguments
 ---------
 
-``--level {major,minor,patch}``
-    Desired bump level. If omitted, ``--base`` and ``--head`` are used to determine the level automatically. Defaults to automatic detection.
-
 ``--base BASE``
     Base git reference when auto-deciding the level. Defaults to the last release commit if available, otherwise the previous commit (``HEAD^``).
 
@@ -106,7 +103,7 @@ Examples
 
 .. code-block:: console
 
-   bumpwright bump --level minor --pyproject pyproject.toml --commit --tag
+   bumpwright bump --pyproject pyproject.toml --commit --tag
 
 This prints the old and new versions and, when ``--commit`` and ``--tag`` are set, commits and tags the release. Omitting ``--base`` compares against the last release commit or the previous commit (``HEAD^``), and omitting ``--head`` assumes ``HEAD``.
 

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -14,7 +14,10 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -24,8 +27,6 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -40,15 +41,18 @@ def test_bump_uses_config_path(tmp_path: Path) -> None:
     output = res.stderr
     content = (repo / "CHANGELOG.md").read_text()
     today = date.today().isoformat()
-    assert f"## [v0.1.1] - {today}" in content
+    assert f"## [v0.2.0] - {today}" in content
     assert f"- {sha} feat: change" in content
-    assert "## [v0.1.1]" not in output
+    assert "## [v0.2.0]" not in output
 
 
 def test_bump_writes_changelog(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -58,8 +62,6 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -76,15 +78,18 @@ def test_bump_writes_changelog(tmp_path: Path) -> None:
     output = res.stderr
     content = (repo / "CHANGELOG.md").read_text()
     today = date.today().isoformat()
-    assert f"## [v0.1.1] - {today}" in content
+    assert f"## [v0.2.0] - {today}" in content
     assert f"- {sha} feat: change" in content
-    assert "## [v0.1.1]" not in output
+    assert "## [v0.2.0]" not in output
 
 
 def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -94,8 +99,6 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -111,7 +114,7 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
     )
     output = res.stderr
     today = date.today().isoformat()
-    assert f"## [v0.1.1] - {today}" in output
+    assert f"## [v0.2.0] - {today}" in output
     assert f"- {sha} feat: change" in output
     assert not (repo / "CHANGELOG.md").exists()
 
@@ -119,7 +122,10 @@ def test_bump_writes_changelog_stdout(tmp_path: Path) -> None:
 def test_changelog_links_repo_url(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     sha = run(["git", "rev-parse", "--short", "HEAD"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -129,8 +135,6 @@ def test_changelog_links_repo_url(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -157,7 +161,10 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     (repo / "tpl.j2").write_text("VERSION={{ version }}\n", encoding="utf-8")
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -166,8 +173,6 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -183,7 +188,7 @@ def test_changelog_custom_template_cli(tmp_path: Path) -> None:
         text=True,
         env=env,
     )
-    assert (repo / "CHANGELOG.md").read_text() == "VERSION=0.1.1\n"
+    assert (repo / "CHANGELOG.md").read_text() == "VERSION=0.2.0\n"
 
 
 def test_changelog_custom_template_config(tmp_path: Path) -> None:
@@ -195,7 +200,10 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "-am", "feat: change"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
     subprocess.run(
@@ -204,8 +212,6 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -217,13 +223,16 @@ def test_changelog_custom_template_config(tmp_path: Path) -> None:
         text=True,
         env=env,
     )
-    assert (repo / "CHANGELOG.md").read_text() == "Built 0.1.1\n"
+    assert (repo / "CHANGELOG.md").read_text() == "Built 0.2.0\n"
 
 
 def test_changelog_exclude_cli(tmp_path: Path) -> None:
     repo, pkg, _ = setup_repo(tmp_path)
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "--allow-empty", "-m", "chore: drop"], repo)
     run(["git", "commit", "-am", "feat: keep"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -233,8 +242,6 @@ def test_changelog_exclude_cli(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",
@@ -262,7 +269,10 @@ def test_changelog_exclude_config(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     run(["git", "commit", "--allow-empty", "-m", "chore(release): 0.1.0"], repo)
-    (pkg / "__init__.py").write_text("def foo() -> int:\n    return 2\n", encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n\ndef bar() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
     run(["git", "commit", "--allow-empty", "-m", "chore: drop"], repo)
     run(["git", "commit", "-am", "feat: keep"], repo)
     env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
@@ -272,8 +282,6 @@ def test_changelog_exclude_config(tmp_path: Path) -> None:
             "-m",
             "bumpwright.cli",
             "bump",
-            "--level",
-            "patch",
             "--pyproject",
             "pyproject.toml",
             "--dry-run",


### PR DESCRIPTION
## Summary
- drop explicit `--level` option and always infer bump level
- update tests and docs to reflect automatic level detection

## Testing
- `ruff check bumpwright tests docs --fix`
- `isort bumpwright/cli/__init__.py bumpwright/cli/bump.py docs/_bumpwright_click.py tests/test_cli_core.py tests/test_cli_bump_format.py tests/test_cli_changelog.py`
- `black bumpwright/cli/__init__.py bumpwright/cli/bump.py docs/_bumpwright_click.py tests/test_cli_core.py tests/test_cli_bump_format.py tests/test_cli_changelog.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec45aaf0832294e8696cded05508