### PR TITLE
fix(changelog): handle contributor errors gracefully

### DIFF
--- a/bumpwright/cli/changelog.py
+++ b/bumpwright/cli/changelog.py
@@ -91,7 +91,7 @@ def _build_changelog(args: Any, new_version: str) -> str | None:
         contributors_raw = collect_contributors(base, args.head)
     except subprocess.CalledProcessError as exc:
         logger.warning("Failed to collect contributors: %s", exc)
-        return None
+        contributors_raw = []
     contributors: list[dict[str, str | None]] = []
     for name, email in contributors_raw:
         link = None


### PR DESCRIPTION
## Summary
- avoid aborting changelog generation when `git shortlog` fails
- add regression test covering contributor collection errors

## Testing
- `ruff check bumpwright/cli/changelog.py tests/test_cli_bump_helpers.py`
- `pytest -q`

## Labels
- fix

------
https://chatgpt.com/codex/tasks/task_e_68a2fefec6a48322a371f2b33efbc705