### PR TITLE
docs(nav): unify navigation labels and toctree

### DIFF
--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -291,8 +291,10 @@ def _build_history_subparser(
 
     parser = subparsers.add_parser(
         "history",
-        help="List existing git tags",
-        description="List git tags with their version numbers.",
+        help="List and roll back releases",
+        description=(
+            "List releases with their version numbers or roll back a tagged release."
+        ),
     )
     parser.add_argument(
         "--format",

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -73,10 +73,10 @@ Common combos
 .. click:: _bumpwright_click:bump
    :prog: bumpwright bump
 
-history
--------
+history – list & rollback releases
+---------------------------------
 
-List git tags, show statistics, or roll back a tagged release.
+List releases, show statistics, or roll back a tagged release.
 
 When to use
 ^^^^^^^^^^^

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -209,11 +209,9 @@ Global options
 
 Commands
 ~~~~~~~~
+Detailed guides for individual commands:
 
-.. toctree::
-   :maxdepth: 1
-
-   usage/init
-   usage/decide
-   usage/bump
-   usage/history
+- :doc:`init – create a baseline <usage/init>`
+- :doc:`decide – compare without changing files <usage/decide>`
+- :doc:`bump – update version files <usage/bump>`
+- :doc:`history – list & rollback releases <usage/history>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,15 @@ Primary use cases
 
 .. toctree::
    :maxdepth: 1
+   :caption: Usage
+
+   usage/init
+   usage/decide
+   usage/bump
+   usage/history
+
+.. toctree::
+   :maxdepth: 1
    :caption: Versioning
 
    concepts/versioning


### PR DESCRIPTION
## Summary
- normalize sidebar sections under a single root toctree and link command guides from *Get Started*
- align history command documentation and CLI help with "list & rollback releases"

## Testing
- `ruff check bumpwright tests --fix`
- `black bumpwright/cli/__init__.py`
- `isort --check-only -v bumpwright/cli/__init__.py`
- `sphinx-build -b html docs docs/_build/html` *(fails: No module named 'graphql')*
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff08cc308322885b7d074357fa63