### PR TITLE
fix(cli): rename format arg to output_fmt

### DIFF
--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -180,6 +180,7 @@ def _build_bump_subparser(
     )
     parser.add_argument(
         "--format",
+        dest="output_fmt",
         choices=["text", "md", "json"],
         default=os.getenv("BUMPWRIGHT_FORMAT", "text"),
         help="Output style: plain text, Markdown, or machine-readable JSON.",
@@ -298,6 +299,7 @@ def _build_history_subparser(
     )
     parser.add_argument(
         "--format",
+        dest="output_fmt",
         choices=["text", "md", "json"],
         default=os.getenv("BUMPWRIGHT_FORMAT", "text"),
         help="Output style: plain text, Markdown, or machine-readable JSON.",

--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -217,7 +217,7 @@ def _display_result(
 ) -> None:
     """Show bump outcome using the selected format."""
 
-    if args.format == "json":
+    if args.output_fmt == "json":
         logger.info(
             json.dumps(
                 {
@@ -232,7 +232,7 @@ def _display_result(
                 indent=2,
             )
         )
-    elif args.format == "md":
+    elif args.output_fmt == "md":
         logger.info(
             "**bumpwright** bumped version: `%s` -> `%s` (%s)",
             vc.old,

--- a/bumpwright/cli/decide.py
+++ b/bumpwright/cli/decide.py
@@ -55,6 +55,7 @@ def add_decide_arguments(parser: argparse.ArgumentParser) -> None:
     add_ref_options(parser)
     parser.add_argument(
         "--format",
+        dest="output_fmt",
         choices=["text", "md", "json"],
         default=os.getenv("BUMPWRIGHT_FORMAT", "text"),
         help="Output style: plain text, Markdown, or machine-readable JSON.",
@@ -336,9 +337,9 @@ def _decide_only(args: argparse.Namespace, cfg: Config) -> int:
     }
     if changelog is not None:
         payload["changelog"] = changelog
-    if args.format == "json":
+    if args.output_fmt == "json":
         logger.info(json.dumps(payload, indent=2))
-    elif args.format == "md":
+    elif args.output_fmt == "md":
         logger.info("**bumpwright** suggests: `%s`", decision.level)
         logger.info("%s", _format_impacts_text(impacts))
         if changelog:

--- a/bumpwright/cli/history.py
+++ b/bumpwright/cli/history.py
@@ -283,7 +283,7 @@ def history_command(args: argparse.Namespace) -> int:  # noqa: PLR0915
         interacting with git.
 
     Example:
-        >>> history_command(argparse.Namespace(format="json", stats=False, rollback=None))  # doctest: +SKIP
+        >>> history_command(argparse.Namespace(output_fmt="json", stats=False, rollback=None))  # doctest: +SKIP
         0
     """
 
@@ -319,9 +319,9 @@ def history_command(args: argparse.Namespace) -> int:  # noqa: PLR0915
             record["stats"] = {"insertions": ins, "deletions": dels}
         records.append(record)
 
-    if args.format == "json":
+    if args.output_fmt == "json":
         logger.info(json.dumps(records, indent=2))
-    elif args.format == "md":
+    elif args.output_fmt == "md":
         header = ["Tag", "Version", "Date"]
         if args.stats:
             header.append("Stats")

--- a/docs/_bumpwright_click.py
+++ b/docs/_bumpwright_click.py
@@ -76,7 +76,7 @@ def init(args: argparse.Namespace, summary: str | None) -> int:
 @click.option("--head", default="HEAD", show_default=True, help="Head git reference.")
 @click.option(
     "--format",
-    "format_",
+    "output_fmt",
     type=click.Choice(["text", "md", "json"]),
     default="text",
     show_default=True,
@@ -127,7 +127,7 @@ def decide(
     args: argparse.Namespace,
     base: str | None,
     head: str,
-    format_: str,
+    output_fmt: str,
     emit_changelog: bool,
     explain: bool,
     repo_url: str | None,
@@ -141,7 +141,7 @@ def decide(
 
     args.base = base
     args.head = head
-    args.format = format_
+    args.output_fmt = output_fmt
     args.emit_changelog = emit_changelog
     args.explain = explain
     args.repo_url = repo_url
@@ -164,7 +164,7 @@ def decide(
 @click.option("--head", default="HEAD", show_default=True, help="Head git reference.")
 @click.option(
     "--format",
-    "format_",
+    "output_fmt",
     type=click.Choice(["text", "md", "json"]),
     default="text",
     show_default=True,
@@ -271,7 +271,7 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
             head (str): Git reference representing the working tree. Defaults
             to ``HEAD``.
 
-            format_ (str): Output format: ``text`` (default), ``md`` for
+            output_fmt (str): Output format: ``text`` (default), ``md`` for
             Markdown, or ``json`` for machine-readable output.
 
             repo_url (str | None): Base repository URL used to build commit
@@ -326,14 +326,13 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
     params["version_path"] = list(params.get("version_path", []))
     params["version_ignore"] = list(params.get("version_ignore", []))
     params["changelog_exclude"] = list(params.get("changelog_exclude", []))
-    params["format"] = params.pop("format_")
     return bump_command(argparse.Namespace(**params))
 
 
 @cli.command()
 @click.option(
     "--format",
-    "format_",
+    "output_fmt",
     type=click.Choice(["text", "md", "json"]),
     default="text",
     show_default=True,
@@ -362,7 +361,7 @@ def bump(args: argparse.Namespace, **kwargs: object) -> int:
 @click.pass_obj
 def history(
     args: argparse.Namespace,
-    format_: str,
+    output_fmt: str,
     local_time: bool,
     stats: bool,
     rollback: str | None,
@@ -372,7 +371,7 @@ def history(
 
     Args:
         args: Parsed command-line arguments from :func:`cli`.
-        format_: Desired output format.
+        output_fmt: Desired output format.
         stats: Whether to include diff statistics between tags.
         rollback: Tag to remove and restore to the previous commit.
         purge: Remove all bumpwright release tags and reset versioned files.
@@ -381,7 +380,7 @@ def history(
         Exit status code, where ``0`` indicates success and ``1`` an error.
     """
 
-    args.format = format_
+    args.output_fmt = output_fmt
     args.local_time = local_time
     args.stats = stats
     args.rollback = rollback

--- a/tests/test_cli_bump.py
+++ b/tests/test_cli_bump.py
@@ -17,7 +17,7 @@ def _args(commit: bool = False, tag: bool = False) -> argparse.Namespace:
         config="bumpwright.toml",
         base=None,
         head="HEAD",
-        format="text",
+        output_fmt="text",
         repo_url=None,
         enable_analyser=[],
         disable_analyser=[],

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -135,7 +135,7 @@ def test_resolve_pyproject_missing() -> None:
 
 
 def test_display_result_json(caplog) -> None:
-    args = argparse.Namespace(format="json")
+    args = argparse.Namespace(output_fmt="json")
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("pyproject.toml")])
     dec = Decision("minor", 1.0, [])
     with caplog.at_level(logging.INFO):
@@ -146,7 +146,7 @@ def test_display_result_json(caplog) -> None:
 
 
 def test_display_result_text_skipped(caplog) -> None:
-    args = argparse.Namespace(format="text")
+    args = argparse.Namespace(output_fmt="text")
     vc = VersionChange(
         "0.1.0",
         "0.2.0",
@@ -512,7 +512,7 @@ def test_resolve_pyproject_uses_find(
 def test_display_result_md(caplog: pytest.LogCaptureFixture) -> None:
     """Markdown format lists updated and skipped files."""
 
-    args = argparse.Namespace(format="md")
+    args = argparse.Namespace(output_fmt="md")
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("a")], [Path("b")])
     dec = Decision("minor", 1.0, [])
     with caplog.at_level(logging.INFO):

--- a/tests/test_cli_decide_helpers.py
+++ b/tests/test_cli_decide_helpers.py
@@ -13,22 +13,26 @@ from bumpwright.config import Config
 def test_build_api_skips_unparsed_file(monkeypatch: pytest.MonkeyPatch) -> None:
     """Files that fail to parse are ignored."""
 
-    monkeypatch.setattr(decide, "list_py_files_at_ref", lambda ref, roots, ignore_globs=None: ["mod.py"])
+    monkeypatch.setattr(
+        decide, "list_py_files_at_ref", lambda ref, roots, ignore_globs=None: ["mod.py"]
+    )
     monkeypatch.setattr(decide, "parse_python_source", lambda ref, path: None)
     api = decide._build_api_at_ref("HEAD", ["."], [], [])
     assert api == {}
 
 
-def test_add_decide_arguments_includes_format() -> None:
+def test_add_decide_arguments_includes_output_fmt() -> None:
     """Parser gains the ``--format`` option with default ``text``."""
 
     parser = argparse.ArgumentParser()
     decide.add_decide_arguments(parser)
     args = parser.parse_args([])
-    assert args.format == "text"
+    assert args.output_fmt == "text"
 
 
-def test_decide_only_md_format(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_decide_only_md_format(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Markdown output is produced when requested."""
 
     cfg = Config()
@@ -37,11 +41,13 @@ def test_decide_only_md_format(monkeypatch: pytest.MonkeyPatch, caplog: pytest.L
         head="HEAD",
         enable_analyser=None,
         disable_analyser=None,
-        format="md",
+        output_fmt="md",
         explain=False,
     )
     monkeypatch.setattr(decide, "_collect_impacts", lambda b, h, c, a: [])
-    monkeypatch.setattr(decide, "decide_bump", lambda impacts: Decision("patch", 1.0, []))
+    monkeypatch.setattr(
+        decide, "decide_bump", lambda impacts: Decision("patch", 1.0, [])
+    )
     with caplog.at_level(logging.INFO):
         assert decide._decide_only(args, cfg) == 0
     assert "**bumpwright** suggests" in caplog.text

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -510,7 +510,7 @@ def test_history_rollback_tag_delete_failure(
     monkeypatch.chdir(repo)
     with caplog.at_level(logging.ERROR):
         res = history_command(
-            argparse.Namespace(format="text", stats=False, rollback="v0.2.0")
+            argparse.Namespace(output_fmt="text", stats=False, rollback="v0.2.0")
         )
     assert res == 1
     assert "Failed to delete tag v0.2.0" in caplog.text

--- a/tests/test_cli_subparsers.py
+++ b/tests/test_cli_subparsers.py
@@ -37,7 +37,7 @@ def test_build_bump_subparser_registers_arguments() -> None:
         "head",
         "enable_analyser",
         "disable_analyser",
-        "format",
+        "output_fmt",
         "repo_url",
         "pyproject",
         "version_path",
@@ -63,4 +63,4 @@ def test_build_decide_subparser_registers_command() -> None:
     assert sub.choices["decide"] is decide_parser
     assert decide_parser.get_default("func") is decide_command
     dests = {action.dest for action in decide_parser._actions}
-    assert {"base", "head", "format", "emit_changelog", "explain"} <= dests
+    assert {"base", "head", "output_fmt", "emit_changelog", "explain"} <= dests


### PR DESCRIPTION
## Summary
- rename CLI `format` argument and docs variable to `output_fmt`
- update command logic and tests for new `output_fmt`

## Testing
- `ruff check --fix bumpwright/cli/__init__.py bumpwright/cli/bump.py bumpwright/cli/decide.py bumpwright/cli/history.py tests/test_cli_bump_helpers.py tests/test_cli_bump.py tests/test_cli_history.py tests/test_cli_subparsers.py tests/test_cli_decide_helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3393269fc8322b30857716f963efd