### PR TITLE
docs(bump): start CLI reference with example

### DIFF
--- a/docs/usage/bump.rst
+++ b/docs/usage/bump.rst
@@ -1,5 +1,8 @@
 bumpwright bump
 ===============
+.. code-block:: console
+
+   bumpwright bump --commit --tag
 
 Update version information in ``pyproject.toml`` and other files. By default, ``bumpwright`` also searches ``setup.py``, ``setup.cfg`` and any ``__init__.py``, ``version.py`` or ``_version.py`` files for a version assignment. Files inside common build artefacts and virtual environments are ignored by default (``build/**``, ``dist/**``, ``*.egg-info/**``, ``.eggs/**``, ``.venv/**``, ``venv/**``, ``.env/**`` and ``**/__pycache__/**``). These locations can be customised via the ``[version]`` section in ``bumpwright.toml`` or augmented with ``--version-path`` and ``--version-ignore`` to add or exclude patterns. See :doc:`../guides/version-management/version-file-targeting` for targeting specific version files.
 


### PR DESCRIPTION
## Summary
- start bump CLI docs with example snippet

## Testing
- `ruff check .`
- `black --check docs/usage/bump.rst` *(fails: Cannot parse .rst)*
- `isort docs/usage/bump.rst --check-only`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a56f3a8b048322ac2ba527d6b02030