### PR TITLE
docs(decide): showcase explain decision anatomy

### DIFF
--- a/docs/usage/decide.rst
+++ b/docs/usage/decide.rst
@@ -76,3 +76,53 @@ Examples
            ],
            "changelog": "### 0.2.0 - 2023-01-01\n- add greet command\n"
          }
+
+Decision anatomy
+----------------
+
+``bumpwright`` can justify its suggestions with ``--explain``. The flag logs
+detected impacts and applied rules to ``stderr`` while the chosen level remains
+on ``stdout``. This makes it easy to see which default or custom rules produced
+each human-friendly reason.
+
+.. tab-set::
+
+   .. tab-item:: Console
+      :sync: console
+
+      .. code-block:: console
+
+         $ bumpwright decide --base origin/main --format text --explain
+         minor
+
+         Detected impacts:
+         - Added public symbol ``cli.new_command`` (rule: added_symbol)
+         Applied rules: added_symbol=minor
+         Chosen bump level: minor
+
+   .. tab-item:: Markdown
+      :sync: markdown
+
+      .. markdown::
+
+         **bumpwright** suggests: `minor`
+         - added CLI entry 'greet'
+
+         Detected impacts:
+         - Added public symbol ``cli.new_command`` (rule: added_symbol)
+         Applied rules: added_symbol=minor
+         Chosen bump level: minor
+
+   .. tab-item:: Json
+      :sync: json
+
+      .. code-block:: json
+
+         {
+           "level": "minor",
+           "confidence": 1.0,
+           "reasons": ["added CLI entry 'greet'"],
+           "impacts": [
+             {"severity": "minor", "symbol": "cli.new_command", "reason": "added CLI entry 'greet'"}
+           ]
+         }


### PR DESCRIPTION
## Summary
- document `--explain` output in a new "Decision anatomy" section
- show console/markdown/json examples linking reasons to applied rules

## Testing
- `isort docs/usage/decide.rst --check-only`
- `black . --check` *(fails: would reformat multiple files)*
- `ruff check docs/usage/decide.rst`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57c3d305883228ad0e25cd9e48343