### PR TITLE
docs(decide): document changelog options

### DIFF
--- a/docs/usage/decide.rst
+++ b/docs/usage/decide.rst
@@ -12,6 +12,9 @@ Primary options
 * ``--emit-changelog`` – print the expected changelog for the suggested version.
 * ``--explain`` – show reasoning behind the suggested bump.
 * ``--no-impl-change-patch`` – ignore implementation-only changes to public symbols.
+* ``--repo-url URL`` – base repository URL used for commit links in changelog output.
+* ``--changelog-template PATH`` – Jinja2 template file for changelog entries.
+* ``--changelog-exclude REGEX`` – regex pattern for commit subjects to omit from changelog entries.
 
 Arguments
 ---------
@@ -33,6 +36,15 @@ Arguments
 
 ``--no-impl-change-patch``
     Do not treat implementation-only changes as patch-level impacts.
+
+``--repo-url URL``
+    Base repository URL used to build commit links in changelog output. Overrides ``[changelog].repo_url`` when provided. Defaults to none, showing raw commit hashes when unset.
+
+``--changelog-template PATH``
+    Jinja2 template file used when rendering changelog entries. Defaults to the built-in template or ``[changelog].template`` when configured. Useful for customising changelog layout.
+
+``--changelog-exclude REGEX``
+    Regex pattern for commit subjects to exclude from changelog entries. Repeatable. Patterns from configuration are combined with CLI values.
 
 ``--enable-analyser NAME``
     Enable analyser ``NAME`` in addition to configuration. Repeatable. Defaults to none.


### PR DESCRIPTION
## Summary
- document `--repo-url` for commit links in changelog output
- explain `--changelog-template` for custom Jinja2 templates
- describe `--changelog-exclude` to filter commit subjects

## Testing
- `ruff check .`
- `black . --check` *(fails: would reformat existing files)*
- `isort . --check-only` *(fails: imports not sorted in existing files)*
- `pytest`

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_68a58dda92ac8322a3663a5160642031