### PR TITLE
docs(init): require explicit summary format

### DIFF
--- a/docs/usage/init.rst
+++ b/docs/usage/init.rst
@@ -6,8 +6,8 @@ Record an empty ``chore(release): initialise baseline`` commit so that future ru
 Primary options
 ---------------
 
-* ``--summary [table|json]`` – Show project summary after initialisation.
-  Defaults to ``table`` when no format is specified.
+* ``--summary [table|json]`` – Show project summary after initialisation in the chosen format.
+  Must be followed by ``table`` or ``json``.
 
 Examples
 --------
@@ -19,7 +19,7 @@ Examples
 
       .. code-block:: console
 
-         bumpwright init --summary
+         bumpwright init --summary table
 
    .. tab-item:: Markdown
       :sync: markdown


### PR DESCRIPTION
## Summary
- clarify that `--summary` requires an explicit format value
- update examples to show `--summary table`

## Testing
- `ruff check .`
- `black --check docs/usage/init.rst` (fails: cannot format RST)
- `isort --check-only docs/usage/init.rst`
- `pytest`

Label: docs

------
https://chatgpt.com/codex/tasks/task_e_68a591774bdc83229cd3b2e20b1e9050