### PR TITLE
docs(urls): set canonical documentation domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Bumpwright is an automated semantic versioning tool that scans your code changes—not just commit messages—to suggest the right next version. In a single command, it compares your latest code against the last release and tells you whether to bump the version by a patch, minor, or major, making accurate releases effortless for maintainers of libraries and services with stable interfaces.
 
-**Docs:** https://lewis-morris.github.io/bumpwright
+**Docs:** https://lewis-morris.github.io/bumpwright/
 **Guides:** https://lewis-morris.github.io/bumpwright/guides/
 
 ## Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = ["semantic-versioning", "semver", "api", "diff", "release"]
 [project.urls]
 homepage = "https://github.com/arched-dev/bumpwright"
 repository = "https://github.com/arched-dev/bumpwright"
-documentation = "https://bumpwright.readthedocs.io"
+documentation = "https://lewis-morris.github.io/bumpwright/"
 bug_tracker = "https://github.com/arched-dev/bumpwright/issues"
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- point project metadata to GitHub Pages docs
- ensure README docs link uses the same domain

## Testing
- ⚠️ `black --check bumpwright tests` (would reformat 15 files)
- ⚠️ `isort bumpwright tests --check-only` (imports incorrectly sorted in tests/test_parse_errors.py)
- ✅ `ruff check .`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a59182a2088322b2115925693e3f83