### PR TITLE
docs(readme): add gRPC analyser entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Enable what you need in `[analysers]` or per-run with `--enable-analyser/--disab
 
 - **Python API (default)** – respects `__all__`; otherwise public = names not starting with `_`.  
 - **CLI** – detects changes to argparse/Click commands.  
+- **gRPC** – service and method diffs.
 - **Web routes** – Flask/FastAPI route changes.  
 - **Migrations** – Alembic schema impacts.  
 - **OpenAPI** – spec diffs.  


### PR DESCRIPTION
## Summary
- document gRPC analyser capabilities

## Testing
- `ruff check .`
- `black . --check` *(fails: would reformat multiple files)*
- `isort . --check-only` *(fails: imports incorrectly sorted)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5918a51a88322a49e4c6a29245598