### PR TITLE
docs(docs): standardise analyser spelling

### DIFF
--- a/docs/analysers/index.rst
+++ b/docs/analysers/index.rst
@@ -1,13 +1,13 @@
-Analyzers Guide
+Analysers Guide
 ===============
 
-Analyzers inspect different facets of your project to detect API changes.
-Bumpwright ships optional analyzers for the :doc:`CLI <cli>`, :doc:`gRPC <grpc>` services,
+Analysers inspect different facets of your project to detect API changes.
+Bumpwright ships optional analysers for the :doc:`CLI <cli>`, :doc:`gRPC <grpc>` services,
 :doc:`web routes <web_routes>`, :doc:`database migrations <migrations>`, :doc:`OpenAPI documents <openapi>`
-and :doc:`GraphQL schemas <graphql>`. The table below lists each analyzer, the key used
+and :doc:`GraphQL schemas <graphql>`. The table below lists each analyser, the key used
 to configure it, and the CLI flag to enable it for a single run.
 
-.. list-table:: Available analyzers
+.. list-table:: Available analysers
    :header-rows: 1
 
    * - Analyser
@@ -32,7 +32,7 @@ to configure it, and the CLI flag to enable it for a single run.
      - ``graphql``
      - ``--enable-analyser graphql``
 
-Enable analyzers in ``bumpwright.toml``:
+Enable analysers in ``bumpwright.toml``:
 
 .. code-block:: toml
 
@@ -50,7 +50,7 @@ Enable analyzers in ``bumpwright.toml``:
    [openapi]
    paths = ["openapi.yaml"]
 
-You can also toggle analyzers per invocation with the command-line flags
+You can also toggle analysers per invocation with the command-line flags
 ``--enable-analyser`` and ``--disable-analyser``.
 
 Python API analyser

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,11 +45,11 @@ New to Bumpwright? Start with the :doc:`quickstart`.
 
    concepts/configuration
 
-.. toctree::
-   :caption: Analyzers Guide
-   :maxdepth: 1
+  .. toctree::
+     :caption: Analysers Guide
+     :maxdepth: 1
 
-   analysers/index
+     analysers/index
 
 .. toctree::
    :caption: Versioning Concepts


### PR DESCRIPTION
## Summary
- adopt British spelling for analyser references

## Testing
- `ruff check .`
- `black . --check` *(fails: 18 files would be reformatted)*
- `isort . --check-only` *(fails: imports incorrectly sorted)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5951b4dd48322b2a395d796fcd7de