### PR TITLE
docs(configuration): add configuration summary table

### DIFF
--- a/docs/concepts/configuration.rst
+++ b/docs/concepts/configuration.rst
@@ -8,6 +8,9 @@ back to built-in defaults. Use ``--config`` to point to an alternative file.
    Environment variables prefixed with ``BUMPWRIGHT_`` provide default values
    for CLI flags. See :ref:`config-envvars` for the full list.
 
+For a side-by-side comparison of CLI flags, configuration keys, and environment
+variables, see :doc:`../configuration_summary`.
+
 .. _config-overview:
 
 Configuration overview

--- a/docs/configuration_summary.rst
+++ b/docs/configuration_summary.rst
@@ -1,0 +1,78 @@
+Configuration Summary
+=====================
+
+This table maps configuration options between the command line, ``bumpwright.toml``, and environment variables. Blank cells indicate that no equivalent is available.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 1 1 1
+
+   * - CLI flag
+     - ``bumpwright.toml`` key
+     - Environment variable
+   * - ``--config``
+     - (n/a)
+     - ``BUMPWRIGHT_CONFIG``
+   * - ``--quiet``
+     - (n/a)
+     - ``BUMPWRIGHT_QUIET``
+   * - ``--verbose``
+     - (n/a)
+     - ``BUMPWRIGHT_VERBOSE``
+   * - ``--summary``
+     - (n/a)
+     - ``BUMPWRIGHT_SUMMARY``
+   * - ``--base``
+     - (n/a)
+     - ``BUMPWRIGHT_BASE``
+   * - ``--head``
+     - (n/a)
+     - ``BUMPWRIGHT_HEAD``
+   * - ``--format``
+     - (n/a)
+     - ``BUMPWRIGHT_FORMAT``
+   * - ``--repo-url``
+     - ``[changelog].repo_url``
+     - ``BUMPWRIGHT_REPO_URL``
+   * - ``--explain``
+     - (n/a)
+     - ``BUMPWRIGHT_EXPLAIN``
+   * - ``--enable-analyser NAME``
+     - ``[analysers].<name> = true``
+     - ``BUMPWRIGHT_ENABLE_ANALYSER``
+   * - ``--disable-analyser NAME``
+     - ``[analysers].<name> = false``
+     - ``BUMPWRIGHT_DISABLE_ANALYSER``
+   * - ``--pyproject``
+     - (n/a)
+     - ``BUMPWRIGHT_PYPROJECT``
+   * - ``--version-path``
+     - ``[version].paths``
+     - ``BUMPWRIGHT_VERSION_PATH``
+   * - ``--version-ignore``
+     - ``[version].ignore``
+     - ``BUMPWRIGHT_VERSION_IGNORE``
+   * - ``--tag``
+     - (n/a)
+     - ``BUMPWRIGHT_TAG``
+   * - ``--dry-run``
+     - (n/a)
+     - ``BUMPWRIGHT_DRY_RUN``
+   * - ``--changelog``
+     - ``[changelog].path``
+     - ``BUMPWRIGHT_CHANGELOG``
+   * - ``--changelog-template``
+     - ``[changelog].template``
+     - ``BUMPWRIGHT_CHANGELOG_TEMPLATE``
+   * - ``--changelog-exclude``
+     - ``[changelog].exclude``
+     - ``BUMPWRIGHT_CHANGELOG_EXCLUDE``
+   * - ``--stats``
+     - (n/a)
+     - ``BUMPWRIGHT_STATS``
+   * - ``--rollback``
+     - (n/a)
+     - ``BUMPWRIGHT_ROLLBACK``
+   * - ``--purge``
+     - (n/a)
+     - ``BUMPWRIGHT_PURGE``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,12 +44,13 @@ New to Bumpwright? Start with the :doc:`quickstart`.
    :maxdepth: 1
 
    concepts/configuration
+   configuration_summary
 
-  .. toctree::
-     :caption: Analysers Guide
-     :maxdepth: 1
+.. toctree::
+   :caption: Analysers Guide
+   :maxdepth: 1
 
-     analysers/index
+   analysers/index
 
 .. toctree::
    :caption: Versioning Concepts


### PR DESCRIPTION
## Summary
- add configuration summary table linking CLI flags, configuration keys, and environment variables
- reference summary from configuration guide and index

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 18 files)*
- `isort --check-only .` *(fails: imports not sorted)*
- `pytest`
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc5486608322837a194031c9f9d3