### PR TITLE
feat(cli): add flag to toggle skipped files output

### DIFF
--- a/bumpwright/cli/__init__.py
+++ b/bumpwright/cli/__init__.py
@@ -186,6 +186,12 @@ def _build_bump_subparser(
         help="Output style: plain text, Markdown, or machine-readable JSON.",
     )
     parser.add_argument(
+        "--show-skipped",
+        action="store_true",
+        default=_env_flag("BUMPWRIGHT_SHOW_SKIPPED"),
+        help="Display files skipped during version updates.",
+    )
+    parser.add_argument(
         "--repo-url",
         default=os.getenv("BUMPWRIGHT_REPO_URL"),
         help=(

--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -216,22 +216,19 @@ def _display_result(
     args: argparse.Namespace, vc: VersionChange, decision: Decision
 ) -> None:
     """Show bump outcome using the selected format."""
-
+    show_skipped = getattr(args, "show_skipped", False)
     if args.output_fmt == "json":
-        logger.info(
-            json.dumps(
-                {
-                    "old_version": vc.old,
-                    "new_version": vc.new,
-                    "level": vc.level,
-                    "confidence": decision.confidence,
-                    "reasons": decision.reasons,
-                    "files": [str(p) for p in vc.files],
-                    "skipped": [str(p) for p in vc.skipped],
-                },
-                indent=2,
-            )
-        )
+        payload = {
+            "old_version": vc.old,
+            "new_version": vc.new,
+            "level": vc.level,
+            "confidence": decision.confidence,
+            "reasons": decision.reasons,
+            "files": [str(p) for p in vc.files],
+        }
+        if show_skipped:
+            payload["skipped"] = [str(p) for p in vc.skipped]
+        logger.info(json.dumps(payload, indent=2))
     elif args.output_fmt == "md":
         logger.info(
             "**bumpwright** bumped version: `%s` -> `%s` (%s)",
@@ -243,7 +240,7 @@ def _display_result(
             "Updated files:\n%s",
             format_bullet_list((str(p) for p in vc.files), True),
         )
-        if vc.skipped:
+        if show_skipped and vc.skipped:
             logger.info(
                 "Skipped files:\n%s",
                 format_bullet_list((str(p) for p in vc.skipped), True),
@@ -259,7 +256,7 @@ def _display_result(
             "Updated files:\n%s",
             format_bullet_list((str(p) for p in vc.files), False),
         )
-        if vc.skipped:
+        if show_skipped and vc.skipped:
             logger.info(
                 "Skipped files:\n%s",
                 format_bullet_list((str(p) for p in vc.skipped), False),

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -135,7 +135,7 @@ def test_resolve_pyproject_missing() -> None:
 
 
 def test_display_result_json(caplog) -> None:
-    args = argparse.Namespace(output_fmt="json")
+    args = argparse.Namespace(output_fmt="json", show_skipped=True)
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("pyproject.toml")])
     dec = Decision("minor", 1.0, [])
     with caplog.at_level(logging.INFO):
@@ -146,7 +146,7 @@ def test_display_result_json(caplog) -> None:
 
 
 def test_display_result_text_skipped(caplog) -> None:
-    args = argparse.Namespace(output_fmt="text")
+    args = argparse.Namespace(output_fmt="text", show_skipped=False)
     vc = VersionChange(
         "0.1.0",
         "0.2.0",
@@ -155,6 +155,13 @@ def test_display_result_text_skipped(caplog) -> None:
         [Path("extra.py")],
     )
     dec = Decision("minor", 1.0, [])
+    with caplog.at_level(logging.INFO):
+        _display_result(args, vc, dec)
+    out = "\n".join(record.message for record in caplog.records)
+    assert "Skipped files:" not in out
+
+    args.show_skipped = True
+    caplog.clear()
     with caplog.at_level(logging.INFO):
         _display_result(args, vc, dec)
     out = "\n".join(record.message for record in caplog.records)
@@ -510,11 +517,18 @@ def test_resolve_pyproject_uses_find(
 
 
 def test_display_result_md(caplog: pytest.LogCaptureFixture) -> None:
-    """Markdown format lists updated and skipped files."""
+    """Markdown format lists skipped files only when requested."""
 
-    args = argparse.Namespace(output_fmt="md")
+    args = argparse.Namespace(output_fmt="md", show_skipped=False)
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("a")], [Path("b")])
     dec = Decision("minor", 1.0, [])
+    with caplog.at_level(logging.INFO):
+        _display_result(args, vc, dec)
+    out = "\n".join(r.message for r in caplog.records)
+    assert "Skipped files" not in out
+
+    args.show_skipped = True
+    caplog.clear()
     with caplog.at_level(logging.INFO):
         _display_result(args, vc, dec)
     out = "\n".join(r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add `--show-skipped` flag to bump command to hide or show skipped files
- omit skipped files block by default and update tests

## Testing
- `python -m isort bumpwright/cli/bump.py bumpwright/cli/__init__.py tests/test_cli_bump_helpers.py`
- `python -m black bumpwright/cli/bump.py bumpwright/cli/__init__.py tests/test_cli_bump_helpers.py`
- `python -m ruff check bumpwright/cli/bump.py bumpwright/cli/__init__.py tests/test_cli_bump_helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a95c3a50e48322bbffca27d8d15fa1