### PR TITLE
fix(cli): respect repository root when determining changed paths

### DIFF
--- a/bumpwright/cli/bump.py
+++ b/bumpwright/cli/bump.py
@@ -121,12 +121,15 @@ def _resolve_refs(args: argparse.Namespace) -> tuple[str, str]:
     return base, args.head
 
 
-def _safe_changed_paths(base: str, head: str) -> set[str]:
+def _safe_changed_paths(
+    base: str, head: str, cwd: str | Path | None = None
+) -> set[str]:
     """Return changed paths or raise :class:`GitDiffError` on failure.
 
     Args:
         base: Base git reference for comparison.
         head: Head git reference for comparison.
+        cwd: Repository path in which to execute ``git``.
 
     Returns:
         Set of paths changed between ``base`` and ``head``.
@@ -137,7 +140,7 @@ def _safe_changed_paths(base: str, head: str) -> set[str]:
     """
 
     try:
-        return changed_paths(base, head)
+        return changed_paths(base, head, cwd=str(cwd) if cwd else None)
     except (
         subprocess.CalledProcessError
     ) as exc:  # pragma: no cover - exercised in tests
@@ -201,7 +204,7 @@ def _prepare_version_files(
     paths = list(cfg.version.paths)
     if args.version_path:
         paths.extend(args.version_path)
-    changed = _safe_changed_paths(base, head)
+    changed = _safe_changed_paths(base, head, cwd=pyproject.parent)
     filtered = {
         p
         for p in changed

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -117,7 +117,9 @@ def test_prepare_version_files_glob_absolute(tmp_path: Path) -> None:
 def test_safe_changed_paths_errors(monkeypatch) -> None:
     """Ensure a descriptive error is raised for diff failures."""
 
-    def fail(base: str, head: str) -> set[str]:
+    def fail(
+        base: str, head: str, cwd: str | Path | None = None
+    ) -> set[str]:  # noqa: ARG001
         raise subprocess.CalledProcessError(1, ["git", "diff"])
 
     monkeypatch.setattr("bumpwright.cli.bump.changed_paths", fail)

--- a/tests/test_cli_bump_subdir.py
+++ b/tests/test_cli_bump_subdir.py
@@ -1,0 +1,51 @@
+import argparse
+import logging
+from pathlib import Path
+
+import pytest
+from cli_helpers import run, setup_repo
+
+from bumpwright.cli.bump import bump_command
+
+
+def _args() -> argparse.Namespace:
+    """Construct arguments for ``bump_command``."""
+    return argparse.Namespace(
+        config="bumpwright.toml",
+        base=None,
+        head="HEAD",
+        output_fmt="text",
+        repo_url=None,
+        enable_analyser=[],
+        disable_analyser=[],
+        pyproject="pyproject.toml",
+        version_path=[],
+        version_ignore=[],
+        commit=False,
+        tag=False,
+        dry_run=False,
+        changelog=None,
+        changelog_template=None,
+        changelog_exclude=[],
+    )
+
+
+def test_no_bump_from_subdir_version_only(
+    monkeypatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Running from a subdirectory skips bump when only version files changed."""
+    repo, pkg, _ = setup_repo(tmp_path)
+    pyproject = repo / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\nname = 'demo'\nversion = '0.1.1'\n", encoding="utf-8"
+    )
+    run(["git", "add", "pyproject.toml"], repo)
+    run(["git", "commit", "-m", "chore: bump version"], repo)
+
+    monkeypatch.chdir(pkg)
+    args = _args()
+    args.config = "../bumpwright.toml"
+    with caplog.at_level(logging.INFO):
+        res = bump_command(args)
+    assert res == 0
+    assert "No version bump needed" in caplog.text


### PR DESCRIPTION
## Summary
- ensure `_safe_changed_paths` forwards repository context for `git` comparisons
- use repository-relative paths when gathering version file changes
- cover subdirectory invocation with regression test

## Testing
- `ruff check bumpwright/cli/bump.py tests/test_cli_bump_helpers.py tests/test_cli_bump_subdir.py`
- `PYTEST_ADDOPTS='' pytest`

## Labels
- fix

------
https://chatgpt.com/codex/tasks/task_e_68a95c3b7e3883228848afea4fae4979