### PR TITLE
fix(gitutils): resolve refs before caching

### DIFF
--- a/bumpwright/gitutils.py
+++ b/bumpwright/gitutils.py
@@ -119,6 +119,24 @@ def run_git(
         ) from exc
 
 
+def _resolve_ref(ref: str, cwd: str | None = None) -> str:
+    """Return the commit hash for ``ref``.
+
+    Args:
+        ref: Git reference to resolve.
+        cwd: Repository path.
+
+    Returns:
+        Resolved commit hash.
+
+    Raises:
+        subprocess.CalledProcessError: If ``git rev-parse`` fails.
+    """
+
+    out = _run(["git", "rev-parse", ref], cwd)
+    return out.strip()
+
+
 def changed_paths(base: str, head: str, cwd: str | None = None) -> set[str]:
     """Return paths changed between two git references.
 
@@ -220,7 +238,8 @@ def list_py_files_at_ref(
 
     roots_tuple = tuple(roots)
     ignores_tuple = tuple(ignore_globs or ())
-    return set(_list_py_files_at_ref_cached(ref, roots_tuple, ignores_tuple, cwd))
+    commit = _resolve_ref(ref, cwd)
+    return set(_list_py_files_at_ref_cached(commit, roots_tuple, ignores_tuple, cwd))
 
 
 list_py_files_at_ref.cache_clear = _list_py_files_at_ref_cached.cache_clear  # type: ignore[attr-defined]
@@ -338,7 +357,8 @@ def read_files_at_ref(
     """
 
     paths_tuple = tuple(paths)
-    return dict(_read_files_at_ref_cached(ref, paths_tuple, cwd))
+    commit = _resolve_ref(ref, cwd)
+    return dict(_read_files_at_ref_cached(commit, paths_tuple, cwd))
 
 
 read_files_at_ref.cache_clear = _read_files_at_ref_cached.cache_clear  # type: ignore[attr-defined]

--- a/tests/test_cli_bump_helpers.py
+++ b/tests/test_cli_bump_helpers.py
@@ -150,6 +150,12 @@ def test_display_result_json(caplog) -> None:
 def test_display_result_text_no_skipped(caplog) -> None:
     args = argparse.Namespace(output_fmt="text")
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("pyproject.toml")])
+    dec = Decision("minor", 1.0, [])
+    with caplog.at_level(logging.INFO):
+        _display_result(args, vc, dec)
+    out = "\n".join(record.message for record in caplog.records)
+    assert "Skipped files:" not in out
+
 
 def test_display_result_text_skipped(caplog) -> None:
     args = argparse.Namespace(output_fmt="text", show_skipped=False)
@@ -520,15 +526,23 @@ def test_display_result_md_no_skipped(caplog: pytest.LogCaptureFixture) -> None:
 
     args = argparse.Namespace(output_fmt="md")
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("a")])
+    dec = Decision("minor", 1.0, [])
+    with caplog.at_level(logging.INFO):
+        _display_result(args, vc, dec)
+    out = "\n".join(r.message for r in caplog.records)
+    assert "Updated files" in out and "Skipped files" not in out
+
 
 def test_display_result_md(caplog: pytest.LogCaptureFixture) -> None:
     """Markdown format lists skipped files only when requested."""
 
     args = argparse.Namespace(output_fmt="md", show_skipped=False)
     vc = VersionChange("0.1.0", "0.2.0", "minor", [Path("a")], [Path("b")])
-
+    dec = Decision("minor", 1.0, [])
+    with caplog.at_level(logging.INFO):
+        _display_result(args, vc, dec)
+    out = "\n".join(r.message for r in caplog.records)
     assert "Updated files" in out and "Skipped files" not in out
-    assert "Skipped files" not in out
 
     args.show_skipped = True
     caplog.clear()


### PR DESCRIPTION
## Summary
- resolve git refs to commit hashes before caching file lists and contents
- add regression test ensuring API diff notices new commits
- fix CLI display result tests to validate output correctly

## Testing
- `isort bumpwright/gitutils.py tests/test_parse_cache.py tests/test_cli_bump_helpers.py`
- `black bumpwright/gitutils.py tests/test_parse_cache.py tests/test_cli_bump_helpers.py`
- `ruff check bumpwright/gitutils.py tests/test_parse_cache.py tests/test_cli_bump_helpers.py`
- `pytest`

Labels: fix

------
https://chatgpt.com/codex/tasks/task_e_68a96ddbeb8c83229d8ba26f076cd4d5